### PR TITLE
fix: Content-Length header + img2img reference images support

### DIFF
--- a/.squad/agents/jayne/history.md
+++ b/.squad/agents/jayne/history.md
@@ -27,3 +27,31 @@
 - DetectBestProvider_IsCached
 
 **Key learning:** Always verify that attribute packages are referenced when introducing new xUnit extensions like SkippableFact/SkippableTheory.
+
+### 2025-07-25: HTTP-level tests for Flux2Generator (Issues #5 & #6)
+
+**Context:** Wrote 43 new tests covering Wash's Content-Length fix (Issue #5) and Kaylee's img2img reference images feature (Issue #6). Baseline was 87 tests, now 130 — all green on net8.0 and net10.0.
+
+**Test file:** `src/ElBruno.Text2Image.Tests/Flux2GeneratorHttpTests.cs`
+
+**Key patterns established:**
+- `FakeHttpHandler` — a reusable `HttpMessageHandler` that intercepts requests, captures headers/body, and returns canned responses. Inject via `Flux2Generator(..., httpClient: httpClient)`.
+- `FakeHttpHandler.CreateSuccessResponse()` — returns a minimal `{"created":1234,"data":[{"b64_json":"..."}]}` so GenerateAsync completes successfully.
+- `InternalsVisibleTo` added to `ElBruno.Text2Image.Foundry.csproj` → allows direct `Flux2Request` / `Flux2JsonContext` serialization tests.
+
+**Edge cases discovered:**
+- `ArgumentException.ThrowIfNullOrWhiteSpace(null)` throws `ArgumentNullException` (subclass), so tests must use `Assert.ThrowsAny<ArgumentException>`, not `Assert.Throws<ArgumentException>`.
+- Non-existent file path may throw `DirectoryNotFoundException` (not `FileNotFoundException`) if the parent directory is also missing. Use `Assert.ThrowsAny<IOException>`.
+- `JsonIgnore(Condition = WhenWritingNull)` on `List<string>?` correctly omits null but preserves empty arrays — important for the API contract.
+
+**Source stubs added:**
+- `ImageGenerationOptions.ReferenceImages` (property) and `AddReferenceImageFromFile()` (convenience method) — merged with Kaylee's existing property, added file-to-DataURI helper.
+- `Flux2Request.ReferenceImages` with `[JsonIgnore(WhenWritingNull)]` — already present from Kaylee's work.
+
+**Test classes and counts:**
+- `Flux2GeneratorContentLengthTests` — 10 tests (Content-Length, valid JSON, fields, API key, POST method, error handling)
+- `ImageGenerationOptionsReferenceImagesTests` — 8 tests (default null, set, round-trip, empty, single, multi, reset to null)
+- `AddReferenceImageFromFileTests` — 11 tests (PNG/JPEG/WEBP, multiple files, append, unknown ext, null/empty/whitespace/missing file)
+- `Flux2RequestSerializationTests` — 5 tests (null omits, single, empty array, multiple, required fields)
+- `Flux2GeneratorReferenceImagesTests` — 9 tests (include/omit/null/multi/empty in request body, file-based, result validity)
+

--- a/.squad/agents/kaylee/history.md
+++ b/.squad/agents/kaylee/history.md
@@ -11,3 +11,9 @@
 ## Learnings
 
 *Append new learnings below this line.*
+
+- **img2img feature (2025-07-25):** Added `ReferenceImages` property to `ImageGenerationOptions` and `Flux2Request`. The `Flux2Request` uses source-generated `Flux2JsonContext` so new nullable properties with `[JsonIgnore(WhenWritingNull)]` are automatically handled — no manual context changes needed.
+- **Flux2Generator serialization pattern:** Request bodies use `JsonSerializer.SerializeToUtf8Bytes` + `ByteArrayContent` to ensure `Content-Length` is set (BFL API requirement). All request property additions flow through this path automatically.
+- **M.E.AI integration:** `Text2ImagePropertyNames` in `Extensions/MeaiIntegration.cs` defines well-known keys for `AdditionalProperties` passthrough. New options should add a constant there and handle it in both `FromMeaiOptions` and the generator's explicit M.E.AI implementation.
+- **Key file paths:** `ImageGenerationOptions.cs` (shared options), `Flux2Generator.cs` (cloud API generator + JSON DTOs + `Flux2JsonContext`), `Extensions/MeaiIntegration.cs` (M.E.AI converter + property names).
+- **Build command:** `dotnet build ElBruno.Text2Image.slnx --no-restore` — verified clean (0 warnings, 0 errors).

--- a/.squad/agents/wash/history.md
+++ b/.squad/agents/wash/history.md
@@ -11,3 +11,8 @@
 ## Learnings
 
 *Append new learnings below this line.*
+
+- **BFL API Content-Length requirement (2025-07-25):** The Black Forest Labs API on Azure Foundry requires an explicit `Content-Length` header. `JsonContent.Create()` may use chunked transfer encoding, which omits it. Use `JsonSerializer.SerializeToUtf8Bytes()` + `ByteArrayContent` instead.
+- **Source-generated JSON context:** `Flux2JsonContext` is the source-generated `JsonSerializerContext` for Foundry request/response types. Always use it for serialization (e.g., `Flux2JsonContext.Default.Flux2Request`).
+- **Key file:** `src/ElBruno.Text2Image.Foundry/Flux2Generator.cs` — FLUX.2 cloud API client (BFL Native API via Azure Foundry). Handles both sync (200) and async (202 + polling) patterns.
+- **Build/test commands:** `dotnet build --no-restore` and `dotnet test --no-build` — multi-target (net8.0 + net10.0), 87 tests per TFM.

--- a/.squad/decisions/inbox/jayne-test-strategy.md
+++ b/.squad/decisions/inbox/jayne-test-strategy.md
@@ -1,0 +1,26 @@
+# Decision: HTTP-Level Test Infrastructure for Flux2Generator
+
+**Author:** Jayne (Tester)
+**Date:** 2025-07-25
+**Status:** Implemented
+
+## Context
+
+Issues #5 (Content-Length fix) and #6 (img2img reference images) both require verifying the HTTP request that `Flux2Generator` sends. The existing test suite had no way to inspect outgoing HTTP requests.
+
+## Decision
+
+Introduced `FakeHttpHandler` — a test-only `HttpMessageHandler` that captures request headers, body, and returns canned responses. Tests inject it via `Flux2Generator(..., httpClient: new HttpClient(handler))`.
+
+This pattern should be used for all future `Flux2Generator` HTTP behavior tests.
+
+## Key details
+
+- `InternalsVisibleTo` added to `ElBruno.Text2Image.Foundry.csproj` so tests can directly verify `Flux2Request` serialization via `Flux2JsonContext`.
+- All new tests live in `Flux2GeneratorHttpTests.cs`, separate from the original `ImageGenerationTests.cs`.
+- `AddReferenceImageFromFile` was added to `ImageGenerationOptions` as a convenience method for the img2img feature.
+
+## Impact
+
+- Kaylee / Wash: Future HTTP-level behavior changes should have corresponding tests using `FakeHttpHandler`.
+- Mal: The `InternalsVisibleTo` is test-project-only and doesn't affect the public API surface.

--- a/.squad/decisions/inbox/kaylee-img2img-feature.md
+++ b/.squad/decisions/inbox/kaylee-img2img-feature.md
@@ -1,0 +1,21 @@
+# Decision: img2img ReferenceImages API shape
+
+**Author:** Kaylee (Core Dev)
+**Date:** 2025-07-25
+**Status:** Implemented
+
+## Context
+
+Issue #6 requested image-to-image support for `Flux2Generator`. The BFL API accepts reference images as URLs, base64 strings, or Data URIs in a `referenceImages` array on the request body.
+
+## Decision
+
+- `ReferenceImages` is a `List<string>?` on both `ImageGenerationOptions` (public) and `Flux2Request` (internal). Nullable + `[JsonIgnore(WhenWritingNull)]` preserves backward compat for text-to-image calls.
+- A convenience overload `GenerateAsync(prompt, referenceImagePath, options?, ct)` handles file→base64 Data URI conversion so callers don't need to manually encode.
+- M.E.AI consumers pass reference images via `AdditionalProperties["reference_images"]` as `List<string>`. This follows the existing pattern for `num_inference_steps`, `seed`, etc.
+
+## Implications
+
+- **Jayne (Tests):** New overload and property need test coverage. The convenience overload throws `FileNotFoundException` for missing paths.
+- **River (AI/ML):** Model-specific limits (FLUX.2-pro: 8 images, FLUX.2-flex: 10) are not enforced client-side — the API returns errors for violations. Consider adding client-side validation later if needed.
+- **Mal (Architecture):** The `IImageGenerator` interface was intentionally NOT changed to add a reference-image overload, keeping it simple. The file-path overload is Flux2Generator-specific.

--- a/.squad/decisions/inbox/wash-content-length-fix.md
+++ b/.squad/decisions/inbox/wash-content-length-fix.md
@@ -1,0 +1,20 @@
+# Decision: Use ByteArrayContent for BFL API requests
+
+**Date:** 2025-07-25
+**Author:** Wash (Backend Dev)
+**Status:** Implemented
+**Issue:** #5
+
+## Context
+
+The BFL (Black Forest Labs) API on Azure Foundry began requiring an explicit `Content-Length` header on all requests (reported since April 12, 2026). The previous implementation used `JsonContent.Create()`, which can use chunked transfer encoding and omit `Content-Length`.
+
+## Decision
+
+Serialize the JSON request body to UTF-8 bytes using the source-generated `Flux2JsonContext`, then construct a `ByteArrayContent` with `application/json; charset=utf-8` content type. `ByteArrayContent` always sets `Content-Length` from the byte array length.
+
+## Implications
+
+- Any future HTTP POST/PUT calls to the BFL API should follow this pattern (serialize to bytes first, then `ByteArrayContent`).
+- This is safer in general for APIs that reject chunked transfer encoding.
+- No public API surface was changed — this is an internal implementation detail.

--- a/src/ElBruno.Text2Image.Foundry/ElBruno.Text2Image.Foundry.csproj
+++ b/src/ElBruno.Text2Image.Foundry/ElBruno.Text2Image.Foundry.csproj
@@ -20,6 +20,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="ElBruno.Text2Image.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ElBruno.Text2Image\ElBruno.Text2Image.csproj" />
   </ItemGroup>
 

--- a/src/ElBruno.Text2Image.Foundry/Flux2Generator.cs
+++ b/src/ElBruno.Text2Image.Foundry/Flux2Generator.cs
@@ -193,7 +193,8 @@ public sealed class Flux2Generator : IImageGenerator, Microsoft.Extensions.AI.II
             N = 1,
             Width = options.Width,
             Height = options.Height,
-            OutputFormat = "png"
+            OutputFormat = "png",
+            ReferenceImages = options.ReferenceImages
         };
 
         using var request = new HttpRequestMessage(HttpMethod.Post, _endpoint);
@@ -304,6 +305,42 @@ public sealed class Flux2Generator : IImageGenerator, Microsoft.Extensions.AI.II
     }
 
     /// <summary>
+    /// Generates an image using a text prompt and a reference image file.
+    /// The file is read, converted to a base64 Data URI, and passed as a reference image.
+    /// </summary>
+    /// <param name="prompt">The text description of the image to generate.</param>
+    /// <param name="referenceImagePath">Path to a reference image file (PNG, JPEG, or WebP).</param>
+    /// <param name="options">Optional generation options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The generation result containing the image data.</returns>
+    public async Task<ImageGenerationResult> GenerateAsync(
+        string prompt,
+        string referenceImagePath,
+        ImageGenerationOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(referenceImagePath, nameof(referenceImagePath));
+        if (!File.Exists(referenceImagePath))
+            throw new FileNotFoundException("Reference image file not found.", referenceImagePath);
+
+        var imageBytes = await File.ReadAllBytesAsync(referenceImagePath, cancellationToken);
+        var mimeType = Path.GetExtension(referenceImagePath).ToLowerInvariant() switch
+        {
+            ".png" => "image/png",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".webp" => "image/webp",
+            _ => "application/octet-stream"
+        };
+        var dataUri = $"data:{mimeType};base64,{Convert.ToBase64String(imageBytes)}";
+
+        options ??= new ImageGenerationOptions();
+        options.ReferenceImages ??= [];
+        options.ReferenceImages.Add(dataUri);
+
+        return await GenerateAsync(prompt, options, cancellationToken);
+    }
+
+    /// <summary>
     /// Polls the operation-location URL until the async operation completes.
     /// </summary>
     private async Task<Flux2Response> PollForResultAsync(
@@ -390,6 +427,13 @@ public sealed class Flux2Generator : IImageGenerator, Microsoft.Extensions.AI.II
             localOptions.Width = size.Width;
             localOptions.Height = size.Height;
         }
+
+        if (options?.AdditionalProperties?.TryGetValue(Text2ImagePropertyNames.ReferenceImages, out var refImages) == true
+            && refImages is List<string> refList)
+        {
+            localOptions.ReferenceImages = refList;
+        }
+
         var result = await GenerateAsync(imageRequest.Prompt ?? "", localOptions, cancellationToken);
         return ImageGenerationOptionsConverter.ToMeaiResponse(result);
     }
@@ -427,6 +471,10 @@ internal sealed class Flux2Request
 
     [JsonPropertyName("output_format")]
     public string OutputFormat { get; set; } = "png";
+
+    [JsonPropertyName("referenceImages")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? ReferenceImages { get; set; }
 }
 
 internal sealed class Flux2Response

--- a/src/ElBruno.Text2Image.Foundry/Flux2Generator.cs
+++ b/src/ElBruno.Text2Image.Foundry/Flux2Generator.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Net;
-using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using ElBruno.Text2Image;
@@ -199,7 +198,12 @@ public sealed class Flux2Generator : IImageGenerator, Microsoft.Extensions.AI.II
 
         using var request = new HttpRequestMessage(HttpMethod.Post, _endpoint);
         request.Headers.TryAddWithoutValidation("api-key", _apiKey);
-        request.Content = JsonContent.Create(requestBody, Flux2JsonContext.Default.Flux2Request);
+
+        // Serialize to bytes so Content-Length is set explicitly.
+        // The BFL API rejects requests without a Content-Length header.
+        var jsonBytes = JsonSerializer.SerializeToUtf8Bytes(requestBody, Flux2JsonContext.Default.Flux2Request);
+        request.Content = new ByteArrayContent(jsonBytes);
+        request.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json") { CharSet = "utf-8" };
 
         var response = await _httpClient.SendAsync(request, cancellationToken);
 

--- a/src/ElBruno.Text2Image.Tests/Flux2GeneratorHttpTests.cs
+++ b/src/ElBruno.Text2Image.Tests/Flux2GeneratorHttpTests.cs
@@ -1,0 +1,757 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using ElBruno.Text2Image;
+using ElBruno.Text2Image.Foundry;
+using Xunit;
+
+namespace ElBruno.Text2Image.Tests;
+
+/// <summary>
+/// Test helper: intercepts HttpClient requests so we can inspect headers, body, etc.
+/// </summary>
+internal sealed class FakeHttpHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, HttpResponseMessage> _responseFactory;
+
+    public HttpRequestMessage? LastRequest { get; private set; }
+    public string? LastRequestBody { get; private set; }
+
+    public FakeHttpHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+    {
+        _responseFactory = responseFactory;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        LastRequest = request;
+        if (request.Content != null)
+            LastRequestBody = await request.Content.ReadAsStringAsync(cancellationToken);
+        return _responseFactory(request);
+    }
+
+    /// <summary>
+    /// Creates a minimal successful FLUX.2 API response with a tiny PNG base64 payload.
+    /// </summary>
+    public static HttpResponseMessage CreateSuccessResponse()
+    {
+        var pngBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47 }; // PNG magic bytes
+        var b64 = Convert.ToBase64String(pngBytes);
+        var json = $$"""{"created":1234,"data":[{"b64_json":"{{b64}}"}]}""";
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+}
+
+// ============================================================
+// Issue #5: Content-Length Fix — Verify ByteArrayContent usage
+// ============================================================
+
+public class Flux2GeneratorContentLengthTests
+{
+    [Fact]
+    public async Task GenerateAsync_Request_HasContentLengthHeader()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        await generator.GenerateAsync("test prompt");
+
+        Assert.NotNull(handler.LastRequest?.Content?.Headers.ContentLength);
+        Assert.True(handler.LastRequest!.Content!.Headers.ContentLength > 0,
+            "Content-Length must be a positive value (BFL API rejects chunked encoding)");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_Request_ContentLengthMatchesBodySize()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        await generator.GenerateAsync("test prompt");
+
+        var declaredLength = handler.LastRequest!.Content!.Headers.ContentLength;
+        var actualBytes = Encoding.UTF8.GetBytes(handler.LastRequestBody!);
+        Assert.Equal(actualBytes.Length, declaredLength);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_Request_BodyIsValidJson()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        await generator.GenerateAsync("test prompt");
+
+        Assert.NotNull(handler.LastRequestBody);
+        var doc = JsonDocument.Parse(handler.LastRequestBody!);
+        Assert.NotEqual(default, doc.RootElement);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_Request_ContainsExpectedFields()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator(
+            "https://example.com/api", "test-key", modelId: "FLUX.2-flex", httpClient: httpClient);
+
+        var options = new ImageGenerationOptions { Width = 768, Height = 512 };
+        await generator.GenerateAsync("a beautiful sunset", options);
+
+        var doc = JsonDocument.Parse(handler.LastRequestBody!);
+        var root = doc.RootElement;
+
+        Assert.Equal("a beautiful sunset", root.GetProperty("prompt").GetString());
+        Assert.Equal("FLUX.2-flex", root.GetProperty("model").GetString());
+        Assert.Equal(768, root.GetProperty("width").GetInt32());
+        Assert.Equal(512, root.GetProperty("height").GetInt32());
+        Assert.Equal(1, root.GetProperty("n").GetInt32());
+        Assert.Equal("png", root.GetProperty("output_format").GetString());
+    }
+
+    [Fact]
+    public async Task GenerateAsync_Request_ContentTypeIsJsonUtf8()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        await generator.GenerateAsync("test");
+
+        var contentType = handler.LastRequest!.Content!.Headers.ContentType!;
+        Assert.Equal("application/json", contentType.MediaType);
+        Assert.Equal("utf-8", contentType.CharSet);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_Request_HasApiKeyHeader()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "my-secret-key", httpClient: httpClient);
+
+        await generator.GenerateAsync("test");
+
+        Assert.True(handler.LastRequest!.Headers.TryGetValues("api-key", out var values));
+        Assert.Contains("my-secret-key", values);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_Request_UsesPostMethod()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        await generator.GenerateAsync("test");
+
+        Assert.Equal(HttpMethod.Post, handler.LastRequest!.Method);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_SuccessfulResponse_ReturnsResult()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        var result = await generator.GenerateAsync("test prompt");
+
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.ImageBytes);
+        Assert.Equal("test prompt", result.Prompt);
+        Assert.Equal("FLUX.2-pro", result.ModelName);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ErrorResponse_ThrowsHttpRequestException()
+    {
+        var handler = new FakeHttpHandler(_ => new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("Bad request body", Encoding.UTF8, "application/json")
+        });
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(
+            () => generator.GenerateAsync("test"));
+        Assert.Contains("BadRequest", ex.Message);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_NotFoundResponse_IncludesHint()
+    {
+        var handler = new FakeHttpHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent("Not found", Encoding.UTF8, "application/json")
+        });
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(
+            () => generator.GenerateAsync("test"));
+        Assert.Contains("Hint", ex.Message);
+        Assert.Contains("BFL Native API", ex.Message);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WithDefaultOptions_UsesDefaultDimensions()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        await generator.GenerateAsync("test");
+
+        var doc = JsonDocument.Parse(handler.LastRequestBody!);
+        Assert.Equal(512, doc.RootElement.GetProperty("width").GetInt32());
+        Assert.Equal(512, doc.RootElement.GetProperty("height").GetInt32());
+    }
+}
+
+// ============================================================
+// Issue #6: ImageGenerationOptions.ReferenceImages property
+// ============================================================
+
+public class ImageGenerationOptionsReferenceImagesTests
+{
+    [Fact]
+    public void ReferenceImages_DefaultIsNull()
+    {
+        var options = new ImageGenerationOptions();
+        Assert.Null(options.ReferenceImages);
+    }
+
+    [Fact]
+    public void ReferenceImages_CanBeSet()
+    {
+        var options = new ImageGenerationOptions
+        {
+            ReferenceImages = new List<string> { "data:image/png;base64,abc123" }
+        };
+        Assert.NotNull(options.ReferenceImages);
+        Assert.Single(options.ReferenceImages);
+    }
+
+    [Fact]
+    public void ReferenceImages_RoundTrips()
+    {
+        var images = new List<string> { "data:image/png;base64,abc", "data:image/jpeg;base64,def" };
+        var options = new ImageGenerationOptions { ReferenceImages = images };
+        Assert.Same(images, options.ReferenceImages);
+    }
+
+    [Fact]
+    public void ReferenceImages_EmptyList_IsNotNull()
+    {
+        var options = new ImageGenerationOptions { ReferenceImages = new List<string>() };
+        Assert.NotNull(options.ReferenceImages);
+        Assert.Empty(options.ReferenceImages);
+    }
+
+    [Fact]
+    public void ReferenceImages_SingleImage()
+    {
+        var options = new ImageGenerationOptions
+        {
+            ReferenceImages = new List<string> { "data:image/png;base64,iVBOR" }
+        };
+        Assert.Single(options.ReferenceImages);
+        Assert.Equal("data:image/png;base64,iVBOR", options.ReferenceImages[0]);
+    }
+
+    [Fact]
+    public void ReferenceImages_MultipleImages()
+    {
+        var images = new List<string>
+        {
+            "data:image/png;base64,img1",
+            "data:image/jpeg;base64,img2",
+            "data:image/webp;base64,img3"
+        };
+        var options = new ImageGenerationOptions { ReferenceImages = images };
+        Assert.Equal(3, options.ReferenceImages!.Count);
+    }
+
+    [Fact]
+    public void ReferenceImages_CanBeSetToNull()
+    {
+        var options = new ImageGenerationOptions
+        {
+            ReferenceImages = new List<string> { "data:image/png;base64,abc" }
+        };
+        options.ReferenceImages = null;
+        Assert.Null(options.ReferenceImages);
+    }
+
+    [Fact]
+    public void DefaultOptions_StillHaveExpectedValues_WithReferenceImagesNull()
+    {
+        var options = new ImageGenerationOptions();
+        Assert.Equal(512, options.Width);
+        Assert.Equal(512, options.Height);
+        Assert.Null(options.Seed);
+        Assert.Null(options.ReferenceImages);
+    }
+}
+
+// ============================================================
+// Issue #6: AddReferenceImageFromFile convenience method
+// ============================================================
+
+public class AddReferenceImageFromFileTests
+{
+    [Fact]
+    public void ReadsFile_ConvertsToBase64DataUri_Png()
+    {
+        var options = new ImageGenerationOptions();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid()}.png");
+        try
+        {
+            var pngBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+            File.WriteAllBytes(tempFile, pngBytes);
+
+            options.AddReferenceImageFromFile(tempFile);
+
+            Assert.NotNull(options.ReferenceImages);
+            Assert.Single(options.ReferenceImages);
+
+            var expectedB64 = Convert.ToBase64String(pngBytes);
+            Assert.Equal($"data:image/png;base64,{expectedB64}", options.ReferenceImages[0]);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ReadsFile_ConvertsToBase64DataUri_Jpeg()
+    {
+        var options = new ImageGenerationOptions();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid()}.jpg");
+        try
+        {
+            File.WriteAllBytes(tempFile, new byte[] { 0xFF, 0xD8, 0xFF });
+            options.AddReferenceImageFromFile(tempFile);
+
+            Assert.StartsWith("data:image/jpeg;base64,", options.ReferenceImages![0]);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ReadsFile_ConvertsToBase64DataUri_JpegExtension()
+    {
+        var options = new ImageGenerationOptions();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid()}.jpeg");
+        try
+        {
+            File.WriteAllBytes(tempFile, new byte[] { 0xFF, 0xD8, 0xFF });
+            options.AddReferenceImageFromFile(tempFile);
+
+            Assert.StartsWith("data:image/jpeg;base64,", options.ReferenceImages![0]);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ReadsFile_ConvertsToBase64DataUri_Webp()
+    {
+        var options = new ImageGenerationOptions();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid()}.webp");
+        try
+        {
+            File.WriteAllBytes(tempFile, new byte[] { 0x52, 0x49, 0x46, 0x46 }); // RIFF header
+            options.AddReferenceImageFromFile(tempFile);
+
+            Assert.StartsWith("data:image/webp;base64,", options.ReferenceImages![0]);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void MultipleFiles_AppendsToList()
+    {
+        var options = new ImageGenerationOptions();
+        var tempFile1 = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid()}.png");
+        var tempFile2 = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid()}.jpg");
+        try
+        {
+            File.WriteAllBytes(tempFile1, new byte[] { 0x89, 0x50, 0x4E, 0x47 });
+            File.WriteAllBytes(tempFile2, new byte[] { 0xFF, 0xD8, 0xFF });
+
+            options.AddReferenceImageFromFile(tempFile1);
+            options.AddReferenceImageFromFile(tempFile2);
+
+            Assert.Equal(2, options.ReferenceImages!.Count);
+            Assert.StartsWith("data:image/png;base64,", options.ReferenceImages[0]);
+            Assert.StartsWith("data:image/jpeg;base64,", options.ReferenceImages[1]);
+        }
+        finally
+        {
+            if (File.Exists(tempFile1)) File.Delete(tempFile1);
+            if (File.Exists(tempFile2)) File.Delete(tempFile2);
+        }
+    }
+
+    [Fact]
+    public void AppendsToExistingList()
+    {
+        var options = new ImageGenerationOptions
+        {
+            ReferenceImages = new List<string> { "data:image/png;base64,existing" }
+        };
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid()}.png");
+        try
+        {
+            File.WriteAllBytes(tempFile, new byte[] { 0x89 });
+            options.AddReferenceImageFromFile(tempFile);
+
+            Assert.Equal(2, options.ReferenceImages!.Count);
+            Assert.Equal("data:image/png;base64,existing", options.ReferenceImages[0]);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void UnknownExtension_UsesOctetStream()
+    {
+        var options = new ImageGenerationOptions();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid()}.xyz");
+        try
+        {
+            File.WriteAllBytes(tempFile, new byte[] { 0x00, 0x01, 0x02 });
+            options.AddReferenceImageFromFile(tempFile);
+
+            Assert.StartsWith("data:application/octet-stream;base64,", options.ReferenceImages![0]);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ThrowsOnNullPath()
+    {
+        var options = new ImageGenerationOptions();
+        Assert.ThrowsAny<ArgumentException>(() => options.AddReferenceImageFromFile(null!));
+    }
+
+    [Fact]
+    public void ThrowsOnEmptyPath()
+    {
+        var options = new ImageGenerationOptions();
+        Assert.Throws<ArgumentException>(() => options.AddReferenceImageFromFile(""));
+    }
+
+    [Fact]
+    public void ThrowsOnWhitespacePath()
+    {
+        var options = new ImageGenerationOptions();
+        Assert.Throws<ArgumentException>(() => options.AddReferenceImageFromFile("   "));
+    }
+
+    [Fact]
+    public void ThrowsOnNonExistentFile()
+    {
+        var options = new ImageGenerationOptions();
+        var fakePath = Path.Combine(Path.GetTempPath(), $"nonexistent_{Guid.NewGuid()}.png");
+        Assert.ThrowsAny<IOException>(() =>
+            options.AddReferenceImageFromFile(fakePath));
+    }
+}
+
+// ============================================================
+// Issue #6: Flux2Request JSON serialization (internal type)
+// ============================================================
+
+public class Flux2RequestSerializationTests
+{
+    [Fact]
+    public void Serialize_WithoutReferenceImages_OmitsField()
+    {
+        var request = new Flux2Request
+        {
+            Prompt = "test",
+            Model = "FLUX.2-pro"
+        };
+
+        var json = JsonSerializer.Serialize(request, Flux2JsonContext.Default.Flux2Request);
+        var doc = JsonDocument.Parse(json);
+
+        Assert.False(doc.RootElement.TryGetProperty("referenceImages", out _),
+            "referenceImages should be omitted when null");
+    }
+
+    [Fact]
+    public void Serialize_WithReferenceImages_IncludesArray()
+    {
+        var request = new Flux2Request
+        {
+            Prompt = "test",
+            Model = "FLUX.2-pro",
+            ReferenceImages = new List<string> { "data:image/png;base64,abc" }
+        };
+
+        var json = JsonSerializer.Serialize(request, Flux2JsonContext.Default.Flux2Request);
+        var doc = JsonDocument.Parse(json);
+
+        Assert.True(doc.RootElement.TryGetProperty("referenceImages", out var refImages));
+        Assert.Equal(JsonValueKind.Array, refImages.ValueKind);
+        Assert.Single(refImages.EnumerateArray().ToList());
+        Assert.Equal("data:image/png;base64,abc", refImages[0].GetString());
+    }
+
+    [Fact]
+    public void Serialize_WithEmptyReferenceImages_IncludesEmptyArray()
+    {
+        var request = new Flux2Request
+        {
+            Prompt = "test",
+            Model = "FLUX.2-pro",
+            ReferenceImages = new List<string>()
+        };
+
+        var json = JsonSerializer.Serialize(request, Flux2JsonContext.Default.Flux2Request);
+        var doc = JsonDocument.Parse(json);
+
+        Assert.True(doc.RootElement.TryGetProperty("referenceImages", out var refImages));
+        Assert.Equal(JsonValueKind.Array, refImages.ValueKind);
+        Assert.Empty(refImages.EnumerateArray().ToList());
+    }
+
+    [Fact]
+    public void Serialize_WithMultipleReferenceImages_IncludesAll()
+    {
+        var request = new Flux2Request
+        {
+            Prompt = "test",
+            Model = "FLUX.2-pro",
+            ReferenceImages = new List<string>
+            {
+                "data:image/png;base64,img1",
+                "data:image/jpeg;base64,img2"
+            }
+        };
+
+        var json = JsonSerializer.Serialize(request, Flux2JsonContext.Default.Flux2Request);
+        var doc = JsonDocument.Parse(json);
+
+        var items = doc.RootElement.GetProperty("referenceImages").EnumerateArray().ToList();
+        Assert.Equal(2, items.Count);
+        Assert.Equal("data:image/png;base64,img1", items[0].GetString());
+        Assert.Equal("data:image/jpeg;base64,img2", items[1].GetString());
+    }
+
+    [Fact]
+    public void Serialize_AlwaysIncludesRequiredFields()
+    {
+        var request = new Flux2Request
+        {
+            Prompt = "hello world",
+            Model = "FLUX.2-flex"
+        };
+
+        var json = JsonSerializer.Serialize(request, Flux2JsonContext.Default.Flux2Request);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("hello world", root.GetProperty("prompt").GetString());
+        Assert.Equal("FLUX.2-flex", root.GetProperty("model").GetString());
+        Assert.True(root.TryGetProperty("n", out _));
+        Assert.True(root.TryGetProperty("width", out _));
+        Assert.True(root.TryGetProperty("height", out _));
+        Assert.True(root.TryGetProperty("output_format", out _));
+    }
+}
+
+// ============================================================
+// Issue #6: GenerateAsync with reference images (integration)
+// ============================================================
+
+public class Flux2GeneratorReferenceImagesTests
+{
+    [Fact]
+    public async Task GenerateAsync_WithReferenceImages_IncludesInRequestBody()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        var options = new ImageGenerationOptions
+        {
+            ReferenceImages = new List<string> { "data:image/png;base64,abc" }
+        };
+
+        await generator.GenerateAsync("test prompt", options);
+
+        var doc = JsonDocument.Parse(handler.LastRequestBody!);
+        Assert.True(doc.RootElement.TryGetProperty("referenceImages", out var refImages),
+            "Request body should contain 'referenceImages' when reference images are provided");
+        Assert.Equal(JsonValueKind.Array, refImages.ValueKind);
+        Assert.Equal("data:image/png;base64,abc", refImages[0].GetString());
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WithoutReferenceImages_OmitsFromRequestBody()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        await generator.GenerateAsync("test prompt");
+
+        var doc = JsonDocument.Parse(handler.LastRequestBody!);
+        Assert.False(doc.RootElement.TryGetProperty("referenceImages", out _),
+            "Request body should NOT contain 'referenceImages' when none are provided");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WithNullReferenceImages_OmitsFromRequestBody()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        var options = new ImageGenerationOptions { ReferenceImages = null };
+        await generator.GenerateAsync("test prompt", options);
+
+        var doc = JsonDocument.Parse(handler.LastRequestBody!);
+        Assert.False(doc.RootElement.TryGetProperty("referenceImages", out _));
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WithMultipleReferenceImages_IncludesAllInRequestBody()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        var options = new ImageGenerationOptions
+        {
+            ReferenceImages = new List<string>
+            {
+                "data:image/png;base64,img1",
+                "data:image/jpeg;base64,img2",
+                "data:image/webp;base64,img3"
+            }
+        };
+
+        await generator.GenerateAsync("test prompt", options);
+
+        var doc = JsonDocument.Parse(handler.LastRequestBody!);
+        var refImages = doc.RootElement.GetProperty("referenceImages");
+        Assert.Equal(3, refImages.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WithEmptyReferenceImages_IncludesEmptyArrayInRequestBody()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        var options = new ImageGenerationOptions
+        {
+            ReferenceImages = new List<string>()
+        };
+
+        await generator.GenerateAsync("test prompt", options);
+
+        var doc = JsonDocument.Parse(handler.LastRequestBody!);
+        Assert.True(doc.RootElement.TryGetProperty("referenceImages", out var refImages));
+        Assert.Equal(0, refImages.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WithReferenceImages_StillIncludesPromptAndModel()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator(
+            "https://example.com/api", "test-key", modelId: "FLUX.2-flex", httpClient: httpClient);
+
+        var options = new ImageGenerationOptions
+        {
+            ReferenceImages = new List<string> { "data:image/png;base64,abc" }
+        };
+
+        await generator.GenerateAsync("describe this image", options);
+
+        var doc = JsonDocument.Parse(handler.LastRequestBody!);
+        Assert.Equal("describe this image", doc.RootElement.GetProperty("prompt").GetString());
+        Assert.Equal("FLUX.2-flex", doc.RootElement.GetProperty("model").GetString());
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WithFileBasedReferenceImage_IncludesDataUri()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid()}.png");
+        try
+        {
+            var pngBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+            File.WriteAllBytes(tempFile, pngBytes);
+
+            var options = new ImageGenerationOptions();
+            options.AddReferenceImageFromFile(tempFile);
+
+            await generator.GenerateAsync("edit this image", options);
+
+            var doc = JsonDocument.Parse(handler.LastRequestBody!);
+            var refImages = doc.RootElement.GetProperty("referenceImages");
+            Assert.Single(refImages.EnumerateArray().ToList());
+
+            var dataUri = refImages[0].GetString()!;
+            Assert.StartsWith("data:image/png;base64,", dataUri);
+            Assert.Equal(Convert.ToBase64String(pngBytes), dataUri["data:image/png;base64,".Length..]);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ReturnsValidResult_WithReferenceImages()
+    {
+        var handler = new FakeHttpHandler(_ => FakeHttpHandler.CreateSuccessResponse());
+        using var httpClient = new HttpClient(handler);
+        using var generator = new Flux2Generator("https://example.com/api", "test-key", httpClient: httpClient);
+
+        var options = new ImageGenerationOptions
+        {
+            ReferenceImages = new List<string> { "data:image/png;base64,abc" }
+        };
+
+        var result = await generator.GenerateAsync("test prompt", options);
+
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.ImageBytes);
+        Assert.Equal("test prompt", result.Prompt);
+    }
+}

--- a/src/ElBruno.Text2Image/Extensions/MeaiIntegration.cs
+++ b/src/ElBruno.Text2Image/Extensions/MeaiIntegration.cs
@@ -22,6 +22,9 @@ public static class Text2ImagePropertyNames
 
     /// <summary>Local model directory override (string).</summary>
     public const string ModelDirectory = "model_directory";
+
+    /// <summary>Reference images for image-to-image generation (List&lt;string&gt;).</summary>
+    public const string ReferenceImages = "reference_images";
 }
 
 /// <summary>
@@ -64,6 +67,9 @@ public static class ImageGenerationOptionsConverter
 
             if (meaiOptions.AdditionalProperties.TryGetValue(Text2ImagePropertyNames.ModelDirectory, out var dir) && dir is string dirStr)
                 options.ModelDirectory = dirStr;
+
+            if (meaiOptions.AdditionalProperties.TryGetValue(Text2ImagePropertyNames.ReferenceImages, out var refImages) && refImages is List<string> refList)
+                options.ReferenceImages = refList;
         }
 
         return options;

--- a/src/ElBruno.Text2Image/ImageGenerationOptions.cs
+++ b/src/ElBruno.Text2Image/ImageGenerationOptions.cs
@@ -74,6 +74,14 @@ public sealed class ImageGenerationOptions
     public int? Seed { get; set; }
 
     /// <summary>
+    /// Optional reference images for image-to-image generation.
+    /// Each entry can be a URL, base64-encoded string, or Data URI.
+    /// Supported by FLUX.2-pro (up to 8), FLUX.2-flex (up to 10),
+    /// and FLUX.1-kontext-pro.
+    /// </summary>
+    public List<string>? ReferenceImages { get; set; }
+
+    /// <summary>
     /// Gets the resolved model directory path.
     /// </summary>
     internal string GetModelDirectory(string modelSubfolder)

--- a/src/ElBruno.Text2Image/ImageGenerationOptions.cs
+++ b/src/ElBruno.Text2Image/ImageGenerationOptions.cs
@@ -77,9 +77,34 @@ public sealed class ImageGenerationOptions
     /// Optional reference images for image-to-image generation.
     /// Each entry can be a URL, base64-encoded string, or Data URI.
     /// Supported by FLUX.2-pro (up to 8), FLUX.2-flex (up to 10),
-    /// and FLUX.1-kontext-pro.
+    /// and FLUX.1-kontext-pro. Defaults to null.
     /// </summary>
     public List<string>? ReferenceImages { get; set; }
+
+    /// <summary>
+    /// Reads an image file from disk, converts it to a base64 Data URI,
+    /// and appends it to <see cref="ReferenceImages"/>.
+    /// </summary>
+    /// <param name="filePath">Path to an image file (png, jpg, jpeg, gif, webp, bmp).</param>
+    public void AddReferenceImageFromFile(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var bytes = File.ReadAllBytes(filePath);
+        var mimeType = Path.GetExtension(filePath).ToLowerInvariant() switch
+        {
+            ".png" => "image/png",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".gif" => "image/gif",
+            ".webp" => "image/webp",
+            ".bmp" => "image/bmp",
+            _ => "application/octet-stream"
+        };
+
+        var dataUri = $"data:{mimeType};base64,{Convert.ToBase64String(bytes)}";
+        ReferenceImages ??= new List<string>();
+        ReferenceImages.Add(dataUri);
+    }
 
     /// <summary>
     /// Gets the resolved model directory path.


### PR DESCRIPTION
## Summary

Fixes two open issues in a single release:

### 🔴 Issue #5 — \
o_content_length_header\ error (Bug Fix)
- **Root cause:** \JsonContent.Create()\ could use chunked transfer encoding without \Content-Length\
- **Fix:** Replaced with \ByteArrayContent\ backed by \SerializeToUtf8Bytes()\ — ensures \Content-Length\ is always set
- **Impact:** All BFL API users were blocked since April 12, 2026

### 🟡 Issue #6 — Image-to-Image (img2img) support (Feature)
- Added \ReferenceImages\ property to \ImageGenerationOptions\ (public API)
- Added \ReferenceImages\ to internal \Flux2Request\ with null-safe JSON serialization
- Wired through \GenerateAsync\ — reference images are sent when provided
- Added \AddReferenceImageFromFile()\ convenience method (reads file → base64 Data URI)
- Added M.E.AI \AdditionalProperties\ passthrough for \eference_images\ key
- Supports FLUX.2-pro (up to 8 refs), FLUX.2-flex (up to 10), FLUX.1-kontext-pro

### 🧪 Tests
- 43 new tests across 5 test classes
- Content-Length header validation with mock HTTP handler
- ReferenceImages property defaults, round-trips, serialization
- AddReferenceImageFromFile with multiple formats, edge cases
- Full integration tests through GenerateAsync with mock HTTP
- **260 tests total, all passing** (130 per framework × net8.0 + net10.0)

Closes #5
Closes #6