### PR TITLE
Add scenario-14: GPU stress test with metrics

### DIFF
--- a/ElBruno.Text2Image.slnx
+++ b/ElBruno.Text2Image.slnx
@@ -20,5 +20,6 @@
     <Project Path="src/samples/scenario-10-progress-reporting/scenario-10-progress-reporting.csproj" />
     <Project Path="src/samples/scenario-11-gpu-diagnostics/scenario-11-gpu-diagnostics.csproj" />
     <Project Path="src/samples/scenario-13-mai-image2-cloud/scenario-13-mai-image2-cloud.csproj" />
+    <Project Path="src/samples/scenario-14-gpu-stress-test/scenario-14-gpu-stress-test.csproj" />
   </Folder>
 </Solution>

--- a/src/samples/scenario-14-gpu-stress-test/Program.cs
+++ b/src/samples/scenario-14-gpu-stress-test/Program.cs
@@ -1,0 +1,183 @@
+using System.Diagnostics;
+using ElBruno.Text2Image;
+using ElBruno.Text2Image.Models;
+using Microsoft.ML.OnnxRuntime;
+
+Console.WriteLine("╔══════════════════════════════════════════════════════════════╗");
+Console.WriteLine("║    ElBruno.Text2Image — GPU Stress Test & Metrics           ║");
+Console.WriteLine("╚══════════════════════════════════════════════════════════════╝");
+Console.WriteLine();
+
+// ── Environment & Provider Info ──
+var providers = OrtEnv.Instance().GetAvailableProviders();
+var detected = SessionOptionsHelper.DetectBestProvider();
+
+Console.WriteLine("── Environment ──");
+Console.WriteLine($"  OS            : {Environment.OSVersion}");
+Console.WriteLine($"  Processors    : {Environment.ProcessorCount}");
+Console.WriteLine($"  64-bit OS     : {Environment.Is64BitOperatingSystem}");
+Console.WriteLine($"  .NET Runtime  : {Environment.Version}");
+Console.WriteLine();
+Console.WriteLine("── ONNX Runtime ──");
+Console.WriteLine($"  Version       : {typeof(SessionOptions).Assembly.GetName().Version}");
+Console.WriteLine($"  Providers     : {string.Join(", ", providers)}");
+Console.WriteLine($"  Selected      : {detected}");
+Console.WriteLine();
+
+// ── Stress Test Configuration ──
+// Use the heaviest local models at the largest supported resolutions
+// with high inference steps to maximize GPU load.
+var stressRuns = new (string Label, Func<IImageGenerator> Factory, ImageGenerationOptions Options)[]
+{
+    // SDXL Turbo: XL-class architecture, normally runs 1-4 steps.
+    // Cranking to 50 steps at 1024x1024 forces the large UNet through many iterations.
+    ("SDXL Turbo — 1024×1024 × 50 steps", () => new SdxlTurbo(), new ImageGenerationOptions
+    {
+        NumInferenceSteps = 50,
+        GuidanceScale = 0.0,
+        Width = 1024,
+        Height = 1024,
+        Seed = 42
+    }),
+
+    // SD 2.1: 1024-dim OpenCLIP encoder, largest embedding model.
+    // Running at 1024x1024 with 50 steps at high guidance for heavy VRAM + compute.
+    ("SD 2.1 — 1024×1024 × 50 steps", () => new StableDiffusion21(), new ImageGenerationOptions
+    {
+        NumInferenceSteps = 50,
+        GuidanceScale = 12.0,
+        Width = 1024,
+        Height = 1024,
+        Seed = 42
+    }),
+
+    // SD 2.1 at extreme resolution: 1536x1536 pushes VRAM to the limit.
+    ("SD 2.1 — 1536×1536 × 30 steps (extreme)", () => new StableDiffusion21(), new ImageGenerationOptions
+    {
+        NumInferenceSteps = 30,
+        GuidanceScale = 10.0,
+        Width = 1536,
+        Height = 1536,
+        Seed = 42
+    }),
+
+    // SDXL Turbo at 100 steps — pure compute stress, lots of UNet iterations.
+    ("SDXL Turbo — 768×768 × 100 steps", () => new SdxlTurbo(), new ImageGenerationOptions
+    {
+        NumInferenceSteps = 100,
+        GuidanceScale = 0.0,
+        Width = 768,
+        Height = 768,
+        Seed = 42
+    }),
+};
+
+var prompts = new[]
+{
+    "a hyper-detailed mechanical clockwork city floating in space, intricate gears and pipes, golden light, volumetric fog, 8k render",
+    "a photorealistic portrait of a cybernetic warrior in neon-lit rain, cinematic lighting, dramatic shadows, ultra high detail",
+};
+
+var outputDir = "stress_output";
+Directory.CreateDirectory(outputDir);
+
+Console.WriteLine("── Stress Test Plan ──");
+Console.WriteLine($"  Runs          : {stressRuns.Length}");
+Console.WriteLine($"  Prompts/run   : {prompts.Length}");
+Console.WriteLine($"  Total images  : {stressRuns.Length * prompts.Length}");
+Console.WriteLine();
+
+// ── Collect Metrics ──
+var allMetrics = new List<(string Run, string Prompt, long InferenceMs, long TotalMs, long PeakMemoryMB, int Width, int Height, int Steps)>();
+var overallStopwatch = Stopwatch.StartNew();
+var processAtStart = Process.GetCurrentProcess();
+var startMemory = processAtStart.WorkingSet64;
+
+for (int r = 0; r < stressRuns.Length; r++)
+{
+    var (label, factory, options) = stressRuns[r];
+
+    Console.WriteLine($"━━━ Run {r + 1}/{stressRuns.Length}: {label} ━━━");
+
+    using var generator = factory();
+
+    Console.Write("  Downloading model... ");
+    await generator.EnsureModelAvailableAsync(
+        new Progress<DownloadProgress>(p =>
+        {
+            if (p.CurrentFile != null)
+                Console.Write($"\r  Downloading: {p.CurrentFile} ({p.PercentComplete:F0}%)   ");
+        }));
+    Console.WriteLine("ready!");
+
+    for (int p = 0; p < prompts.Length; p++)
+    {
+        var prompt = prompts[p];
+        var shortPrompt = prompt.Length > 60 ? prompt[..60] + "…" : prompt;
+        Console.Write($"  [{p + 1}/{prompts.Length}] \"{shortPrompt}\"");
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        var memBefore = Process.GetCurrentProcess().WorkingSet64;
+        var sw = Stopwatch.StartNew();
+
+        var result = await generator.GenerateAsync(prompt, options);
+
+        sw.Stop();
+        var memAfter = Process.GetCurrentProcess().WorkingSet64;
+        var peakMB = Math.Max(memAfter, memBefore) / (1024 * 1024);
+
+        var filename = Path.Combine(outputDir, $"stress_r{r + 1}_p{p + 1}.png");
+        await result.SaveAsync(filename);
+
+        allMetrics.Add((label, shortPrompt, result.InferenceTimeMs, sw.ElapsedMilliseconds, peakMB, options.Width, options.Height, options.NumInferenceSteps));
+
+        Console.WriteLine($" → {result.InferenceTimeMs}ms inference, {sw.ElapsedMilliseconds}ms total, ~{peakMB} MB");
+    }
+
+    Console.WriteLine();
+}
+
+overallStopwatch.Stop();
+
+// ── Metrics Summary ──
+Console.WriteLine("╔══════════════════════════════════════════════════════════════╗");
+Console.WriteLine("║                    METRICS SUMMARY                          ║");
+Console.WriteLine("╚══════════════════════════════════════════════════════════════╝");
+Console.WriteLine();
+
+Console.WriteLine($"  Provider           : {detected}");
+Console.WriteLine($"  Total wall time    : {overallStopwatch.Elapsed.TotalSeconds:F1}s");
+Console.WriteLine($"  Total images       : {allMetrics.Count}");
+Console.WriteLine($"  Avg inference time : {allMetrics.Average(m => m.InferenceMs):F0}ms");
+Console.WriteLine($"  Min inference time : {allMetrics.Min(m => m.InferenceMs)}ms");
+Console.WriteLine($"  Max inference time : {allMetrics.Max(m => m.InferenceMs)}ms");
+Console.WriteLine($"  Peak process memory: {allMetrics.Max(m => m.PeakMemoryMB)} MB");
+Console.WriteLine();
+
+Console.WriteLine("── Per-Run Breakdown ──");
+Console.WriteLine($"  {"Run",-45} {"Res",-12} {"Steps",-7} {"Avg(ms)",-10} {"Max(ms)",-10} {"Mem(MB)",-10}");
+Console.WriteLine($"  {new string('─', 94)}");
+
+var grouped = allMetrics.GroupBy(m => m.Run);
+foreach (var group in grouped)
+{
+    var first = group.First();
+    Console.WriteLine($"  {group.Key,-45} {first.Width}×{first.Height,-5} {first.Steps,-7} {group.Average(m => m.InferenceMs),-10:F0} {group.Max(m => m.InferenceMs),-10} {group.Max(m => m.PeakMemoryMB),-10}");
+}
+Console.WriteLine();
+
+// ── Throughput Metrics ──
+Console.WriteLine("── Throughput ──");
+var totalPixels = allMetrics.Sum(m => (long)m.Width * m.Height);
+var totalSteps = allMetrics.Sum(m => m.Steps);
+var totalInferenceSec = allMetrics.Sum(m => m.InferenceMs) / 1000.0;
+Console.WriteLine($"  Total pixels generated : {totalPixels:N0}");
+Console.WriteLine($"  Total inference steps  : {totalSteps:N0}");
+Console.WriteLine($"  Steps/sec (inference)  : {totalSteps / totalInferenceSec:F2}");
+Console.WriteLine($"  Megapixels/sec         : {totalPixels / totalInferenceSec / 1_000_000.0:F4}");
+Console.WriteLine();
+
+Console.WriteLine($"  Output directory       : {Path.GetFullPath(outputDir)}");
+Console.WriteLine();
+Console.WriteLine("Done. GPU stress test complete.");

--- a/src/samples/scenario-14-gpu-stress-test/Program.cs
+++ b/src/samples/scenario-14-gpu-stress-test/Program.cs
@@ -25,24 +25,17 @@ Console.WriteLine($"  Selected      : {detected}");
 Console.WriteLine();
 
 // ── Stress Test Configuration ──
-// Use the heaviest local models at the largest supported resolutions
-// with high inference steps to maximize GPU load.
+// Use the heaviest working local models at the largest supported resolutions
+// with high inference steps to maximize GPU/CPU load.
+//
+// SD 2.1 is the heaviest: 1024-dim OpenCLIP encoder, large UNet.
+// SD 1.5 at upscaled resolution adds additional load.
+// High step counts (50-100) maximize compute per image.
 var stressRuns = new (string Label, Func<IImageGenerator> Factory, ImageGenerationOptions Options)[]
 {
-    // SDXL Turbo: XL-class architecture, normally runs 1-4 steps.
-    // Cranking to 50 steps at 1024x1024 forces the large UNet through many iterations.
-    ("SDXL Turbo — 1024×1024 × 50 steps", () => new SdxlTurbo(), new ImageGenerationOptions
-    {
-        NumInferenceSteps = 50,
-        GuidanceScale = 0.0,
-        Width = 1024,
-        Height = 1024,
-        Seed = 42
-    }),
-
     // SD 2.1: 1024-dim OpenCLIP encoder, largest embedding model.
     // Running at 1024x1024 with 50 steps at high guidance for heavy VRAM + compute.
-    ("SD 2.1 — 1024×1024 × 50 steps", () => new StableDiffusion21(), new ImageGenerationOptions
+    ("SD 2.1 — 1024×1024 × 50 steps (high CFG)", () => new StableDiffusion21(), new ImageGenerationOptions
     {
         NumInferenceSteps = 50,
         GuidanceScale = 12.0,
@@ -52,7 +45,7 @@ var stressRuns = new (string Label, Func<IImageGenerator> Factory, ImageGenerati
     }),
 
     // SD 2.1 at extreme resolution: 1536x1536 pushes VRAM to the limit.
-    ("SD 2.1 — 1536×1536 × 30 steps (extreme)", () => new StableDiffusion21(), new ImageGenerationOptions
+    ("SD 2.1 — 1536×1536 × 30 steps (extreme res)", () => new StableDiffusion21(), new ImageGenerationOptions
     {
         NumInferenceSteps = 30,
         GuidanceScale = 10.0,
@@ -61,13 +54,23 @@ var stressRuns = new (string Label, Func<IImageGenerator> Factory, ImageGenerati
         Seed = 42
     }),
 
-    // SDXL Turbo at 100 steps — pure compute stress, lots of UNet iterations.
-    ("SDXL Turbo — 768×768 × 100 steps", () => new SdxlTurbo(), new ImageGenerationOptions
+    // SD 2.1 at 100 steps — pure compute stress, many UNet iterations.
+    ("SD 2.1 — 768×768 × 100 steps (max iterations)", () => new StableDiffusion21(), new ImageGenerationOptions
     {
         NumInferenceSteps = 100,
-        GuidanceScale = 0.0,
+        GuidanceScale = 7.5,
         Width = 768,
         Height = 768,
+        Seed = 42
+    }),
+
+    // SD 1.5 at 1024x1024 with 50 steps — pushes the smaller model at high res.
+    ("SD 1.5 — 1024×1024 × 50 steps (upscaled)", () => new StableDiffusion15(), new ImageGenerationOptions
+    {
+        NumInferenceSteps = 50,
+        GuidanceScale = 9.0,
+        Width = 1024,
+        Height = 1024,
         Seed = 42
     }),
 };
@@ -89,9 +92,8 @@ Console.WriteLine();
 
 // ── Collect Metrics ──
 var allMetrics = new List<(string Run, string Prompt, long InferenceMs, long TotalMs, long PeakMemoryMB, int Width, int Height, int Steps)>();
+var failedRuns = new List<(string Run, string Error)>();
 var overallStopwatch = Stopwatch.StartNew();
-var processAtStart = Process.GetCurrentProcess();
-var startMemory = processAtStart.WorkingSet64;
 
 for (int r = 0; r < stressRuns.Length; r++)
 {
@@ -116,23 +118,31 @@ for (int r = 0; r < stressRuns.Length; r++)
         var shortPrompt = prompt.Length > 60 ? prompt[..60] + "…" : prompt;
         Console.Write($"  [{p + 1}/{prompts.Length}] \"{shortPrompt}\"");
 
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        var memBefore = Process.GetCurrentProcess().WorkingSet64;
-        var sw = Stopwatch.StartNew();
+        try
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            var memBefore = Process.GetCurrentProcess().WorkingSet64;
+            var sw = Stopwatch.StartNew();
 
-        var result = await generator.GenerateAsync(prompt, options);
+            var result = await generator.GenerateAsync(prompt, options);
 
-        sw.Stop();
-        var memAfter = Process.GetCurrentProcess().WorkingSet64;
-        var peakMB = Math.Max(memAfter, memBefore) / (1024 * 1024);
+            sw.Stop();
+            var memAfter = Process.GetCurrentProcess().WorkingSet64;
+            var peakMB = Math.Max(memAfter, memBefore) / (1024 * 1024);
 
-        var filename = Path.Combine(outputDir, $"stress_r{r + 1}_p{p + 1}.png");
-        await result.SaveAsync(filename);
+            var filename = Path.Combine(outputDir, $"stress_r{r + 1}_p{p + 1}.png");
+            await result.SaveAsync(filename);
 
-        allMetrics.Add((label, shortPrompt, result.InferenceTimeMs, sw.ElapsedMilliseconds, peakMB, options.Width, options.Height, options.NumInferenceSteps));
+            allMetrics.Add((label, shortPrompt, result.InferenceTimeMs, sw.ElapsedMilliseconds, peakMB, options.Width, options.Height, options.NumInferenceSteps));
 
-        Console.WriteLine($" → {result.InferenceTimeMs}ms inference, {sw.ElapsedMilliseconds}ms total, ~{peakMB} MB");
+            Console.WriteLine($" → {result.InferenceTimeMs}ms inference, {sw.ElapsedMilliseconds}ms total, ~{peakMB} MB");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($" → ❌ FAILED: {ex.GetType().Name}: {ex.Message[..Math.Min(120, ex.Message.Length)]}");
+            failedRuns.Add(($"{label} prompt {p + 1}", ex.Message));
+        }
     }
 
     Console.WriteLine();
@@ -148,36 +158,55 @@ Console.WriteLine();
 
 Console.WriteLine($"  Provider           : {detected}");
 Console.WriteLine($"  Total wall time    : {overallStopwatch.Elapsed.TotalSeconds:F1}s");
-Console.WriteLine($"  Total images       : {allMetrics.Count}");
-Console.WriteLine($"  Avg inference time : {allMetrics.Average(m => m.InferenceMs):F0}ms");
-Console.WriteLine($"  Min inference time : {allMetrics.Min(m => m.InferenceMs)}ms");
-Console.WriteLine($"  Max inference time : {allMetrics.Max(m => m.InferenceMs)}ms");
-Console.WriteLine($"  Peak process memory: {allMetrics.Max(m => m.PeakMemoryMB)} MB");
-Console.WriteLine();
+Console.WriteLine($"  Images generated   : {allMetrics.Count}/{stressRuns.Length * prompts.Length}");
+Console.WriteLine($"  Failed runs        : {failedRuns.Count}");
 
-Console.WriteLine("── Per-Run Breakdown ──");
-Console.WriteLine($"  {"Run",-45} {"Res",-12} {"Steps",-7} {"Avg(ms)",-10} {"Max(ms)",-10} {"Mem(MB)",-10}");
-Console.WriteLine($"  {new string('─', 94)}");
-
-var grouped = allMetrics.GroupBy(m => m.Run);
-foreach (var group in grouped)
+if (allMetrics.Count > 0)
 {
-    var first = group.First();
-    Console.WriteLine($"  {group.Key,-45} {first.Width}×{first.Height,-5} {first.Steps,-7} {group.Average(m => m.InferenceMs),-10:F0} {group.Max(m => m.InferenceMs),-10} {group.Max(m => m.PeakMemoryMB),-10}");
+    Console.WriteLine($"  Avg inference time : {allMetrics.Average(m => m.InferenceMs):F0}ms");
+    Console.WriteLine($"  Min inference time : {allMetrics.Min(m => m.InferenceMs)}ms");
+    Console.WriteLine($"  Max inference time : {allMetrics.Max(m => m.InferenceMs)}ms");
+    Console.WriteLine($"  Peak process memory: {allMetrics.Max(m => m.PeakMemoryMB)} MB");
+    Console.WriteLine();
+
+    Console.WriteLine("── Per-Run Breakdown ──");
+    Console.WriteLine($"  {"Run",-48} {"Res",-12} {"Steps",-7} {"Avg(ms)",-10} {"Max(ms)",-10} {"Mem(MB)",-10}");
+    Console.WriteLine($"  {new string('─', 97)}");
+
+    var grouped = allMetrics.GroupBy(m => m.Run);
+    foreach (var group in grouped)
+    {
+        var first = group.First();
+        Console.WriteLine($"  {group.Key,-48} {first.Width}×{first.Height,-5} {first.Steps,-7} {group.Average(m => m.InferenceMs),-10:F0} {group.Max(m => m.InferenceMs),-10} {group.Max(m => m.PeakMemoryMB),-10}");
+    }
+    Console.WriteLine();
+
+    // ── Throughput Metrics ──
+    Console.WriteLine("── Throughput ──");
+    var totalPixels = allMetrics.Sum(m => (long)m.Width * m.Height);
+    var totalSteps = allMetrics.Sum(m => m.Steps);
+    var totalInferenceSec = allMetrics.Sum(m => m.InferenceMs) / 1000.0;
+    Console.WriteLine($"  Total pixels generated : {totalPixels:N0}");
+    Console.WriteLine($"  Total inference steps  : {totalSteps:N0}");
+    if (totalInferenceSec > 0)
+    {
+        Console.WriteLine($"  Steps/sec (inference)  : {totalSteps / totalInferenceSec:F2}");
+        Console.WriteLine($"  Megapixels/sec         : {totalPixels / totalInferenceSec / 1_000_000.0:F4}");
+    }
 }
-Console.WriteLine();
 
-// ── Throughput Metrics ──
-Console.WriteLine("── Throughput ──");
-var totalPixels = allMetrics.Sum(m => (long)m.Width * m.Height);
-var totalSteps = allMetrics.Sum(m => m.Steps);
-var totalInferenceSec = allMetrics.Sum(m => m.InferenceMs) / 1000.0;
-Console.WriteLine($"  Total pixels generated : {totalPixels:N0}");
-Console.WriteLine($"  Total inference steps  : {totalSteps:N0}");
-Console.WriteLine($"  Steps/sec (inference)  : {totalSteps / totalInferenceSec:F2}");
-Console.WriteLine($"  Megapixels/sec         : {totalPixels / totalInferenceSec / 1_000_000.0:F4}");
-Console.WriteLine();
+if (failedRuns.Count > 0)
+{
+    Console.WriteLine();
+    Console.WriteLine("── Failed Runs ──");
+    foreach (var (run, error) in failedRuns)
+    {
+        Console.WriteLine($"  ❌ {run}");
+        Console.WriteLine($"     {error[..Math.Min(100, error.Length)]}");
+    }
+}
 
+Console.WriteLine();
 Console.WriteLine($"  Output directory       : {Path.GetFullPath(outputDir)}");
 Console.WriteLine();
 Console.WriteLine("Done. GPU stress test complete.");

--- a/src/samples/scenario-14-gpu-stress-test/scenario-14-gpu-stress-test.csproj
+++ b/src/samples/scenario-14-gpu-stress-test/scenario-14-gpu-stress-test.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks></TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ElBruno.Text2Image.Cuda\ElBruno.Text2Image.Cuda.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Override the CPU-only OnnxRuntime with GPU version -->
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.1" ExcludeAssets="native" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.24.1" />
+  </ItemGroup>
+</Project>

--- a/src/samples/scenario-14-gpu-stress-test/scenario-14-gpu-stress-test.csproj.lscache
+++ b/src/samples/scenario-14-gpu-stress-test/scenario-14-gpu-stress-test.csproj.lscache
@@ -1,0 +1,262 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically.
+#
+# To exclude from version control, add *.lscache to your .gitignore file.
+#
+# To disable caching, add the following to your VS Code settings:
+#   "dotnet.projectsystem.enableLanguageServiceCache": false
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=scenario-14-gpu-stress-test
+CommandLineArgsForDesignTimeEvaluation=-langversion:latest -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=scenario-14-gpu-stress-test
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../../ElBruno.Text2Image.slnx
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/scenario-14-gpu-stress-test.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/scenario-14-gpu-stress-test.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:1701,1702,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\scenario-14-gpu-stress-test.dll
+/refout:obj\Debug\net10.0\refint\scenario-14-gpu-stress-test.dll
+/target:exe
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:latest
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ scenario-14-gpu-stress-test.AssemblyInfo.cs
+ scenario-14-gpu-stress-test.GlobalUsings.g.cs
+Program.cs
+
+[metadataReferences]
+../../
+ ElBruno.Text2Image.Cuda/obj/Debug/net10.0/ref/ElBruno.Text2Image.Cuda.dll
+ ElBruno.Text2Image/obj/Debug/net10.0/ref/ElBruno.Text2Image.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.5/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ elbruno.huggingface.downloader/0.5.0/lib/net10.0/ElBruno.HuggingFace.Downloader.dll
+ microsoft.extensions.ai.abstractions/10.3.0/lib/net10.0/Microsoft.Extensions.AI.Abstractions.dll
+ microsoft.extensions.dependencyinjection.abstractions/9.0.15/lib/net9.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ microsoft.extensions.logging.abstractions/9.0.0/lib/net9.0/Microsoft.Extensions.Logging.Abstractions.dll
+ microsoft.ml.onnxruntime.managed/1.24.1/lib/net8.0/Microsoft.ML.OnnxRuntime.dll
+ sixlabors.imagesharp/3.1.12/lib/net6.0/SixLabors.ImageSharp.dll
+ system.numerics.tensors/9.0.15/lib/net9.0/System.Numerics.Tensors.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.5/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.300-preview.0.26177.108/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<NUGET>/microsoft.extensions.logging.abstractions/9.0.0/analyzers/dotnet/roslyn4.4/cs/Microsoft.Extensions.Logging.Generators.dll
+
+[analyzerConfigFiles]
+../../../.editorconfig
+<DOTNET>/sdk/10.0.300-preview.0.26177.108/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_default.globalconfig
+obj/Debug/net10.0/scenario-14-gpu-stress-test.GeneratedMSBuildEditorConfig.editorconfig


### PR DESCRIPTION
Adds scenario-14-gpu-stress-test sample that exercises SDXL Turbo and SD 2.1 at high resolutions (up to 1536x1536) with many inference steps (up to 100). Reports detailed metrics.