### PR TITLE
feat(cli): add 't2i init' command for AI agent skill files

### DIFF
--- a/.claude/skills/t2i/SKILL.md
+++ b/.claude/skills/t2i/SKILL.md
@@ -1,0 +1,154 @@
+# t2i — Text-to-Image CLI Skill
+
+This skill teaches AI agents (GitHub Copilot, Claude Code, and MCP-aware assistants) how to use the **t2i** command-line tool for image generation. Learn the commands, workflows, and best practices for automating text-to-image tasks in scripts and terminal environments.
+
+## When to Use This Skill
+
+Activate this skill when:
+- User asks to generate an image from a text prompt
+- User mentions text-to-image, image generation, or AI images
+- User wants to automate image generation in a script or pipeline
+- User needs batch image generation across multiple prompts
+- User is setting up image generation for CI/CD or deployment workflows
+- User requests help with t2i command syntax or configuration
+
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `t2i config` | Interactive setup wizard (provider, API keys) |
+| `t2i "<prompt>"` | Generate one image from a text prompt |
+| `t2i "<prompt>" --provider <p> --output <file>` | Generate with specific provider and filename |
+| `t2i providers` | List available image generation providers |
+| `t2i secrets set <provider>` | Configure or rotate API credentials securely |
+| `t2i secrets list` | Show stored secrets (redacted) |
+| `t2i doctor` | Run diagnostics (config, API connectivity, secrets) |
+| `t2i version` | Show version and commit SHA |
+| `t2i init` | Write `.github/skills/t2i/SKILL.md` and `.claude/skills/t2i/SKILL.md` to current repo |
+
+## Providers
+
+Two cloud providers available in the **Lite** edition:
+
+| Provider | Model | Use For |
+|----------|-------|---------|
+| `foundry-flux2` | FLUX.2 Pro | High-quality images, fine-grained control, batch jobs |
+| `foundry-mai2` | MAI-Image-2 | Fast iteration, rich prompt understanding, synchronous API |
+
+**Default:** `foundry-flux2` if user doesn't specify `--provider`.
+
+## Common Workflows
+
+### 1. First-Time Setup
+
+```bash
+# Step 1: Interactive config
+t2i config
+
+# Step 2: Enter API credentials when prompted
+# (CLI stores securely via DPAPI on Windows, encrypted on macOS/Linux)
+
+# Step 3: Verify connection
+t2i doctor
+
+# Step 4: Generate your first image
+t2i "a robot painting a landscape"
+```
+
+**Agent tip:** If user skips `t2i config`, they'll get a "not configured" error. Always suggest running it first.
+
+### 2. Generate One Image
+
+```bash
+# Basic: uses default provider and outputs to current directory
+t2i "a cyberpunk city at night, neon lights"
+
+# With custom filename
+t2i "a robot waving" --output my-robot.png
+
+# Specific provider and dimensions
+t2i "minimalist line art of a cat" \
+  --provider foundry-mai2 \
+  --width 1024 \
+  --height 1024 \
+  --output cat.png
+```
+
+### 3. Batch Generate via Shell Loop
+
+**Bash:**
+```bash
+#!/bin/bash
+prompts=(
+  "a robot painting a landscape"
+  "a cyberpunk city at night"
+  "a watercolor painting of a castle"
+)
+
+for prompt in "${prompts[@]}"; do
+  echo "Generating: $prompt"
+  t2i "$prompt" --output "image-$(date +%s).png"
+  sleep 2  # rate limiting
+done
+```
+
+**PowerShell:**
+```powershell
+$prompts = @(
+    "a robot painting a landscape",
+    "a cyberpunk city at night",
+    "a watercolor painting of a castle"
+)
+
+foreach ($prompt in $prompts) {
+    Write-Host "Generating: $prompt"
+    $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    & t2i $prompt --output "image-$timestamp.png"
+    Start-Sleep -Seconds 2  # rate limiting
+}
+```
+
+## Important Rules for Agents
+
+1. **Always verify config first** — Before suggesting any image generation command, check if the user has run `t2i config`. If they haven't, suggest it: "Run `t2i config` first to set up your provider and credentials."
+
+2. **Never expose API keys** — Do not include API keys, tokens, or secrets in code examples, commit messages, or logs. Always direct users to `t2i secrets set` for credential management.
+
+3. **Use environment variables in CI/CD** — For GitHub Actions, Azure Pipelines, or other CI systems, prefer setting `T2I_FOUNDRY_FLUX2_API_KEY` or `T2I_FOUNDRY_MAI2_API_KEY` as secrets, not hardcoded in scripts.
+
+4. **Default to foundry-flux2** — If the user doesn't specify a provider, use `foundry-flux2`. It offers the best quality and control. Only suggest `foundry-mai2` if the user prefers speed or has specific MAI compatibility needs.
+
+5. **Use `--output <file>` for predictable filenames** — When scripting batch jobs, always specify `--output` to ensure consistent, parseable filenames. Without it, images go to `generated_<random>.png`.
+
+6. **Run `t2i doctor` to diagnose issues** — If the user reports generation failures or API errors, always suggest `t2i doctor` first. It checks config, secrets, API connectivity, and permission issues in one command.
+
+7. **Suggest `t2i init` for new repos** — When onboarding a new project or repo, offer to run `t2i init` so future AI agents (Copilot, Claude Code) working on that repo will know how to use t2i.
+
+## Secrets & Security
+
+**Storage Priority** (checked in this order):
+1. **Environment variables** — `T2I_<PROVIDER>_<FIELD>` (best for CI/CD)
+2. **DPAPI** (Windows) — `%LOCALAPPDATA%\t2i\secrets.dpapi` encrypted per-user
+3. **Plaintext file** (macOS/Linux) — `~/.config/t2i/secrets.json` with `0600` permissions
+
+**In CI/CD:**
+```yaml
+# GitHub Actions example
+env:
+  T2I_FOUNDRY_FLUX2_API_KEY: ${{ secrets.T2I_API_KEY }}
+  T2I_FOUNDRY_FLUX2_ENDPOINT: ${{ secrets.T2I_ENDPOINT }}
+
+steps:
+  - run: t2i "your prompt" --output image.png
+```
+
+**For local development:**
+- Run `t2i secrets set foundry-flux2` to store credentials securely
+- Never commit secrets files — add `~/.config/t2i/` and `%APPDATA%\t2i\` to `.gitignore`
+
+## More Info
+
+- **Full documentation:** [docs/cli-tool.md](https://github.com/elbruno/ElBruno.Text2Image/blob/main/docs/cli-tool.md)
+- **GitHub repository:** [elbruno/ElBruno.Text2Image](https://github.com/elbruno/ElBruno.Text2Image)
+- **Package:** [NuGet: ElBruno.Text2Image.Cli](https://www.nuget.org/packages/ElBruno.Text2Image.Cli/)
+- **Report issues:** [GitHub Issues](https://github.com/elbruno/ElBruno.Text2Image/issues)

--- a/.github/skills/t2i/SKILL.md
+++ b/.github/skills/t2i/SKILL.md
@@ -1,0 +1,154 @@
+# t2i — Text-to-Image CLI Skill
+
+This skill teaches AI agents (GitHub Copilot, Claude Code, and MCP-aware assistants) how to use the **t2i** command-line tool for image generation. Learn the commands, workflows, and best practices for automating text-to-image tasks in scripts and terminal environments.
+
+## When to Use This Skill
+
+Activate this skill when:
+- User asks to generate an image from a text prompt
+- User mentions text-to-image, image generation, or AI images
+- User wants to automate image generation in a script or pipeline
+- User needs batch image generation across multiple prompts
+- User is setting up image generation for CI/CD or deployment workflows
+- User requests help with t2i command syntax or configuration
+
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `t2i config` | Interactive setup wizard (provider, API keys) |
+| `t2i "<prompt>"` | Generate one image from a text prompt |
+| `t2i "<prompt>" --provider <p> --output <file>` | Generate with specific provider and filename |
+| `t2i providers` | List available image generation providers |
+| `t2i secrets set <provider>` | Configure or rotate API credentials securely |
+| `t2i secrets list` | Show stored secrets (redacted) |
+| `t2i doctor` | Run diagnostics (config, API connectivity, secrets) |
+| `t2i version` | Show version and commit SHA |
+| `t2i init` | Write `.github/skills/t2i/SKILL.md` and `.claude/skills/t2i/SKILL.md` to current repo |
+
+## Providers
+
+Two cloud providers available in the **Lite** edition:
+
+| Provider | Model | Use For |
+|----------|-------|---------|
+| `foundry-flux2` | FLUX.2 Pro | High-quality images, fine-grained control, batch jobs |
+| `foundry-mai2` | MAI-Image-2 | Fast iteration, rich prompt understanding, synchronous API |
+
+**Default:** `foundry-flux2` if user doesn't specify `--provider`.
+
+## Common Workflows
+
+### 1. First-Time Setup
+
+```bash
+# Step 1: Interactive config
+t2i config
+
+# Step 2: Enter API credentials when prompted
+# (CLI stores securely via DPAPI on Windows, encrypted on macOS/Linux)
+
+# Step 3: Verify connection
+t2i doctor
+
+# Step 4: Generate your first image
+t2i "a robot painting a landscape"
+```
+
+**Agent tip:** If user skips `t2i config`, they'll get a "not configured" error. Always suggest running it first.
+
+### 2. Generate One Image
+
+```bash
+# Basic: uses default provider and outputs to current directory
+t2i "a cyberpunk city at night, neon lights"
+
+# With custom filename
+t2i "a robot waving" --output my-robot.png
+
+# Specific provider and dimensions
+t2i "minimalist line art of a cat" \
+  --provider foundry-mai2 \
+  --width 1024 \
+  --height 1024 \
+  --output cat.png
+```
+
+### 3. Batch Generate via Shell Loop
+
+**Bash:**
+```bash
+#!/bin/bash
+prompts=(
+  "a robot painting a landscape"
+  "a cyberpunk city at night"
+  "a watercolor painting of a castle"
+)
+
+for prompt in "${prompts[@]}"; do
+  echo "Generating: $prompt"
+  t2i "$prompt" --output "image-$(date +%s).png"
+  sleep 2  # rate limiting
+done
+```
+
+**PowerShell:**
+```powershell
+$prompts = @(
+    "a robot painting a landscape",
+    "a cyberpunk city at night",
+    "a watercolor painting of a castle"
+)
+
+foreach ($prompt in $prompts) {
+    Write-Host "Generating: $prompt"
+    $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    & t2i $prompt --output "image-$timestamp.png"
+    Start-Sleep -Seconds 2  # rate limiting
+}
+```
+
+## Important Rules for Agents
+
+1. **Always verify config first** — Before suggesting any image generation command, check if the user has run `t2i config`. If they haven't, suggest it: "Run `t2i config` first to set up your provider and credentials."
+
+2. **Never expose API keys** — Do not include API keys, tokens, or secrets in code examples, commit messages, or logs. Always direct users to `t2i secrets set` for credential management.
+
+3. **Use environment variables in CI/CD** — For GitHub Actions, Azure Pipelines, or other CI systems, prefer setting `T2I_FOUNDRY_FLUX2_API_KEY` or `T2I_FOUNDRY_MAI2_API_KEY` as secrets, not hardcoded in scripts.
+
+4. **Default to foundry-flux2** — If the user doesn't specify a provider, use `foundry-flux2`. It offers the best quality and control. Only suggest `foundry-mai2` if the user prefers speed or has specific MAI compatibility needs.
+
+5. **Use `--output <file>` for predictable filenames** — When scripting batch jobs, always specify `--output` to ensure consistent, parseable filenames. Without it, images go to `generated_<random>.png`.
+
+6. **Run `t2i doctor` to diagnose issues** — If the user reports generation failures or API errors, always suggest `t2i doctor` first. It checks config, secrets, API connectivity, and permission issues in one command.
+
+7. **Suggest `t2i init` for new repos** — When onboarding a new project or repo, offer to run `t2i init` so future AI agents (Copilot, Claude Code) working on that repo will know how to use t2i.
+
+## Secrets & Security
+
+**Storage Priority** (checked in this order):
+1. **Environment variables** — `T2I_<PROVIDER>_<FIELD>` (best for CI/CD)
+2. **DPAPI** (Windows) — `%LOCALAPPDATA%\t2i\secrets.dpapi` encrypted per-user
+3. **Plaintext file** (macOS/Linux) — `~/.config/t2i/secrets.json` with `0600` permissions
+
+**In CI/CD:**
+```yaml
+# GitHub Actions example
+env:
+  T2I_FOUNDRY_FLUX2_API_KEY: ${{ secrets.T2I_API_KEY }}
+  T2I_FOUNDRY_FLUX2_ENDPOINT: ${{ secrets.T2I_ENDPOINT }}
+
+steps:
+  - run: t2i "your prompt" --output image.png
+```
+
+**For local development:**
+- Run `t2i secrets set foundry-flux2` to store credentials securely
+- Never commit secrets files — add `~/.config/t2i/` and `%APPDATA%\t2i\` to `.gitignore`
+
+## More Info
+
+- **Full documentation:** [docs/cli-tool.md](https://github.com/elbruno/ElBruno.Text2Image/blob/main/docs/cli-tool.md)
+- **GitHub repository:** [elbruno/ElBruno.Text2Image](https://github.com/elbruno/ElBruno.Text2Image)
+- **Package:** [NuGet: ElBruno.Text2Image.Cli](https://www.nuget.org/packages/ElBruno.Text2Image.Cli/)
+- **Report issues:** [GitHub Issues](https://github.com/elbruno/ElBruno.Text2Image/issues)

--- a/docs/20260420-introducing-t2i-cli.md
+++ b/docs/20260420-introducing-t2i-cli.md
@@ -131,7 +131,37 @@ t2i "my prompt" \
 # Show help
 t2i --help
 t2i generate --help
+
+# Teach your AI agent
+t2i init
 ```
+
+---
+
+## 🤖 Teach Your AI Agent — `t2i init`
+
+Inspired by [Aspire's agent init pattern](https://aspire.dev/get-started/ai-coding-agents/), t2i now ships with a skill file your AI coding agent can read. Run this in any repo:
+
+```bash
+t2i init
+```
+
+That writes a `SKILL.md` to both `.github/skills/t2i/` and `.claude/skills/t2i/`. From that point on, GitHub Copilot, Claude Code, and any MCP-aware agent know:
+
+- Which `t2i` commands exist and when to use each one
+- How to set up secrets safely (env vars first, never commit keys)
+- The full provider list and which one to default to
+- Common workflows: first-time setup, single image, batch loops
+
+Want only one target?
+
+```bash
+t2i init --target github   # only .github/skills/t2i/
+t2i init --target claude   # only .claude/skills/t2i/
+t2i init --force           # overwrite existing skill files
+```
+
+The canonical version of this skill also lives in this repo at `.github/skills/t2i/SKILL.md` — that means if you open the ElBruno.Text2Image source itself in Copilot or Claude Code, your agent already knows how to drive the CLI.
 
 ---
 

--- a/src/ElBruno.Text2Image.Cli/Commands/InitCommand.cs
+++ b/src/ElBruno.Text2Image.Cli/Commands/InitCommand.cs
@@ -1,0 +1,156 @@
+using System.ComponentModel;
+using System.Reflection;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace ElBruno.Text2Image.Cli.Commands;
+
+/// <summary>
+/// Initializes the current folder with a t2i skill file for AI coding agents.
+/// </summary>
+internal sealed class InitCommand : Command<InitCommand.Settings>
+{
+    public sealed class Settings : CommandSettings
+    {
+        [CommandOption("--target <TARGET>")]
+        [Description("Target platform(s): github, claude, or all (default: all)")]
+        [DefaultValue("all")]
+        public string Target { get; set; } = "all";
+
+        [CommandOption("--force")]
+        [Description("Overwrite existing files")]
+        public bool Force { get; set; }
+    }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        var skillContent = LoadEmbeddedSkillContent();
+        if (skillContent == null)
+        {
+            AnsiConsole.MarkupLine("[red]Error:[/] Failed to load embedded SKILL.md resource");
+            return 1;
+        }
+
+        var targets = GetTargets(settings.Target);
+        if (targets.Count == 0)
+        {
+            AnsiConsole.MarkupLineInterpolated($"[red]Error:[/] Invalid target '{Markup.Escape(settings.Target)}'. Valid values: github, claude, all");
+            return 1;
+        }
+
+        var cwd = Directory.GetCurrentDirectory();
+        var results = new List<(string Path, string Status)>();
+
+        foreach (var target in targets)
+        {
+            var relativePath = GetRelativePath(target);
+            var fullPath = Path.Combine(cwd, relativePath);
+            var (status, written) = WriteSkillFile(fullPath, skillContent, settings.Force);
+            results.Add((relativePath, status));
+        }
+
+        // Display results
+        AnsiConsole.WriteLine();
+        foreach (var (path, status) in results)
+        {
+            var escapedPath = Markup.Escape(path);
+            var (icon, color) = status switch
+            {
+                "created" => ("✓", "green"),
+                "updated" => ("→", "yellow"),
+                "skipped" => ("•", "dim"),
+                _ => ("✗", "red")
+            };
+
+            AnsiConsole.MarkupLineInterpolated($"[{color}]{icon}[/] {escapedPath} [{color}]{status}[/]");
+        }
+
+        // Summary panel
+        var createdCount = results.Count(r => r.Status == "created");
+        var updatedCount = results.Count(r => r.Status == "updated");
+        var skippedCount = results.Count(r => r.Status == "skipped");
+
+        var summaryLines = new List<string>();
+        if (createdCount > 0)
+            summaryLines.Add($"[green]{createdCount} created[/]");
+        if (updatedCount > 0)
+            summaryLines.Add($"[yellow]{updatedCount} updated[/]");
+        if (skippedCount > 0)
+            summaryLines.Add($"[dim]{skippedCount} skipped (use --force to overwrite)[/]");
+
+        if (summaryLines.Count > 0)
+        {
+            AnsiConsole.WriteLine();
+            var panel = new Panel(string.Join(", ", summaryLines))
+            {
+                Header = new PanelHeader("Summary", Justify.Left),
+                Border = BoxBorder.Rounded,
+                BorderStyle = new Style(Color.Grey)
+            };
+            AnsiConsole.Write(panel);
+        }
+
+        return 0;
+    }
+
+    private static string? LoadEmbeddedSkillContent()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var resourceName = "ElBruno.Text2Image.Cli.Skills.SKILL.md";
+
+        using var stream = assembly.GetManifestResourceStream(resourceName);
+        if (stream == null)
+            return null;
+
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    private static List<string> GetTargets(string target)
+    {
+        return target.ToLowerInvariant() switch
+        {
+            "github" => new List<string> { "github" },
+            "claude" => new List<string> { "claude" },
+            "all" => new List<string> { "github", "claude" },
+            _ => new List<string>()
+        };
+    }
+
+    private static string GetRelativePath(string target)
+    {
+        return target switch
+        {
+            "github" => Path.Combine(".github", "skills", "t2i", "SKILL.md"),
+            "claude" => Path.Combine(".claude", "skills", "t2i", "SKILL.md"),
+            _ => throw new ArgumentException($"Unknown target: {target}")
+        };
+    }
+
+    private static (string Status, bool Written) WriteSkillFile(string fullPath, string content, bool force)
+    {
+        var exists = File.Exists(fullPath);
+
+        if (exists && !force)
+        {
+            return ("skipped", false);
+        }
+
+        try
+        {
+            var directory = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(fullPath, content);
+            return (exists ? "updated" : "created", true);
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLineInterpolated($"[red]Error writing {Markup.Escape(fullPath)}:[/] {Markup.Escape(ex.Message)}");
+            return ("error", false);
+        }
+    }
+}

--- a/src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj
+++ b/src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj
@@ -30,6 +30,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Skills\SKILL.md" LogicalName="ElBruno.Text2Image.Cli.Skills.SKILL.md" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Spectre.Console for TUI rendering and command parsing -->
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />

--- a/src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj
+++ b/src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj
@@ -15,7 +15,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>t2i</ToolCommandName>
     <PackageId>ElBruno.Text2Image.Cli</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Description>Lightweight cross-platform CLI for AI text-to-image generation. Includes cloud providers (Microsoft Foundry FLUX.2, MAI-Image-2). For local CPU/GPU inference, see the upcoming ElBruno.Text2Image.Cli.Full package.</Description>
     <PackageTags>text-to-image;stable-diffusion;flux;mai;ai;image-generation;cli;dotnet-tool</PackageTags>
     <Authors>Bruno Capuano</Authors>

--- a/src/ElBruno.Text2Image.Cli/Program.cs
+++ b/src/ElBruno.Text2Image.Cli/Program.cs
@@ -50,6 +50,13 @@ app.Configure(config =>
     config.AddCommand<VersionCommand>("version")
         .WithDescription("Display version information")
         .WithExample(new[] { "version" });
+
+    // Init command
+    config.AddCommand<InitCommand>("init")
+        .WithDescription("Initialize the current folder with a t2i skill file for AI coding agents")
+        .WithExample(new[] { "init" })
+        .WithExample(new[] { "init", "--target", "github" })
+        .WithExample(new[] { "init", "--force" });
 });
 
 return await app.RunAsync(args);

--- a/src/ElBruno.Text2Image.Cli/README.md
+++ b/src/ElBruno.Text2Image.Cli/README.md
@@ -93,6 +93,14 @@ Run diagnostics:
 t2i doctor
 ```
 
+Initialize AI agent skill file:
+
+```bash
+t2i init
+```
+
+This creates `.github/skills/t2i/SKILL.md` and `.claude/skills/t2i/SKILL.md` in your repository so AI coding agents (GitHub Copilot, Claude Code) automatically know how to use the t2i CLI.
+
 ## Documentation
 
 Full documentation: [docs/cli-tool.md](https://github.com/elbruno/ElBruno.Text2Image/blob/main/docs/cli-tool.md)

--- a/src/ElBruno.Text2Image.Cli/Skills/SKILL.md
+++ b/src/ElBruno.Text2Image.Cli/Skills/SKILL.md
@@ -1,0 +1,154 @@
+# t2i — Text-to-Image CLI Skill
+
+This skill teaches AI agents (GitHub Copilot, Claude Code, and MCP-aware assistants) how to use the **t2i** command-line tool for image generation. Learn the commands, workflows, and best practices for automating text-to-image tasks in scripts and terminal environments.
+
+## When to Use This Skill
+
+Activate this skill when:
+- User asks to generate an image from a text prompt
+- User mentions text-to-image, image generation, or AI images
+- User wants to automate image generation in a script or pipeline
+- User needs batch image generation across multiple prompts
+- User is setting up image generation for CI/CD or deployment workflows
+- User requests help with t2i command syntax or configuration
+
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `t2i config` | Interactive setup wizard (provider, API keys) |
+| `t2i "<prompt>"` | Generate one image from a text prompt |
+| `t2i "<prompt>" --provider <p> --output <file>` | Generate with specific provider and filename |
+| `t2i providers` | List available image generation providers |
+| `t2i secrets set <provider>` | Configure or rotate API credentials securely |
+| `t2i secrets list` | Show stored secrets (redacted) |
+| `t2i doctor` | Run diagnostics (config, API connectivity, secrets) |
+| `t2i version` | Show version and commit SHA |
+| `t2i init` | Write `.github/skills/t2i/SKILL.md` and `.claude/skills/t2i/SKILL.md` to current repo |
+
+## Providers
+
+Two cloud providers available in the **Lite** edition:
+
+| Provider | Model | Use For |
+|----------|-------|---------|
+| `foundry-flux2` | FLUX.2 Pro | High-quality images, fine-grained control, batch jobs |
+| `foundry-mai2` | MAI-Image-2 | Fast iteration, rich prompt understanding, synchronous API |
+
+**Default:** `foundry-flux2` if user doesn't specify `--provider`.
+
+## Common Workflows
+
+### 1. First-Time Setup
+
+```bash
+# Step 1: Interactive config
+t2i config
+
+# Step 2: Enter API credentials when prompted
+# (CLI stores securely via DPAPI on Windows, encrypted on macOS/Linux)
+
+# Step 3: Verify connection
+t2i doctor
+
+# Step 4: Generate your first image
+t2i "a robot painting a landscape"
+```
+
+**Agent tip:** If user skips `t2i config`, they'll get a "not configured" error. Always suggest running it first.
+
+### 2. Generate One Image
+
+```bash
+# Basic: uses default provider and outputs to current directory
+t2i "a cyberpunk city at night, neon lights"
+
+# With custom filename
+t2i "a robot waving" --output my-robot.png
+
+# Specific provider and dimensions
+t2i "minimalist line art of a cat" \
+  --provider foundry-mai2 \
+  --width 1024 \
+  --height 1024 \
+  --output cat.png
+```
+
+### 3. Batch Generate via Shell Loop
+
+**Bash:**
+```bash
+#!/bin/bash
+prompts=(
+  "a robot painting a landscape"
+  "a cyberpunk city at night"
+  "a watercolor painting of a castle"
+)
+
+for prompt in "${prompts[@]}"; do
+  echo "Generating: $prompt"
+  t2i "$prompt" --output "image-$(date +%s).png"
+  sleep 2  # rate limiting
+done
+```
+
+**PowerShell:**
+```powershell
+$prompts = @(
+    "a robot painting a landscape",
+    "a cyberpunk city at night",
+    "a watercolor painting of a castle"
+)
+
+foreach ($prompt in $prompts) {
+    Write-Host "Generating: $prompt"
+    $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    & t2i $prompt --output "image-$timestamp.png"
+    Start-Sleep -Seconds 2  # rate limiting
+}
+```
+
+## Important Rules for Agents
+
+1. **Always verify config first** — Before suggesting any image generation command, check if the user has run `t2i config`. If they haven't, suggest it: "Run `t2i config` first to set up your provider and credentials."
+
+2. **Never expose API keys** — Do not include API keys, tokens, or secrets in code examples, commit messages, or logs. Always direct users to `t2i secrets set` for credential management.
+
+3. **Use environment variables in CI/CD** — For GitHub Actions, Azure Pipelines, or other CI systems, prefer setting `T2I_FOUNDRY_FLUX2_API_KEY` or `T2I_FOUNDRY_MAI2_API_KEY` as secrets, not hardcoded in scripts.
+
+4. **Default to foundry-flux2** — If the user doesn't specify a provider, use `foundry-flux2`. It offers the best quality and control. Only suggest `foundry-mai2` if the user prefers speed or has specific MAI compatibility needs.
+
+5. **Use `--output <file>` for predictable filenames** — When scripting batch jobs, always specify `--output` to ensure consistent, parseable filenames. Without it, images go to `generated_<random>.png`.
+
+6. **Run `t2i doctor` to diagnose issues** — If the user reports generation failures or API errors, always suggest `t2i doctor` first. It checks config, secrets, API connectivity, and permission issues in one command.
+
+7. **Suggest `t2i init` for new repos** — When onboarding a new project or repo, offer to run `t2i init` so future AI agents (Copilot, Claude Code) working on that repo will know how to use t2i.
+
+## Secrets & Security
+
+**Storage Priority** (checked in this order):
+1. **Environment variables** — `T2I_<PROVIDER>_<FIELD>` (best for CI/CD)
+2. **DPAPI** (Windows) — `%LOCALAPPDATA%\t2i\secrets.dpapi` encrypted per-user
+3. **Plaintext file** (macOS/Linux) — `~/.config/t2i/secrets.json` with `0600` permissions
+
+**In CI/CD:**
+```yaml
+# GitHub Actions example
+env:
+  T2I_FOUNDRY_FLUX2_API_KEY: ${{ secrets.T2I_API_KEY }}
+  T2I_FOUNDRY_FLUX2_ENDPOINT: ${{ secrets.T2I_ENDPOINT }}
+
+steps:
+  - run: t2i "your prompt" --output image.png
+```
+
+**For local development:**
+- Run `t2i secrets set foundry-flux2` to store credentials securely
+- Never commit secrets files — add `~/.config/t2i/` and `%APPDATA%\t2i\` to `.gitignore`
+
+## More Info
+
+- **Full documentation:** [docs/cli-tool.md](https://github.com/elbruno/ElBruno.Text2Image/blob/main/docs/cli-tool.md)
+- **GitHub repository:** [elbruno/ElBruno.Text2Image](https://github.com/elbruno/ElBruno.Text2Image)
+- **Package:** [NuGet: ElBruno.Text2Image.Cli](https://www.nuget.org/packages/ElBruno.Text2Image.Cli/)
+- **Report issues:** [GitHub Issues](https://github.com/elbruno/ElBruno.Text2Image/issues)

--- a/src/ElBruno.Text2Image.Tests/ElBruno.Text2Image.Tests.csproj
+++ b/src/ElBruno.Text2Image.Tests/ElBruno.Text2Image.Tests.csproj
@@ -15,6 +15,8 @@
          so native assets from Microsoft.ML.OnnxRuntime don't flow transitively. -->
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.*" />
+    <!-- Spectre.Console.Cli needed for InitCommandTests to construct CommandContext -->
+    <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ElBruno.Text2Image.Tests/InitCommandTests.cs
+++ b/src/ElBruno.Text2Image.Tests/InitCommandTests.cs
@@ -1,0 +1,199 @@
+#if NET10_0_OR_GREATER
+using Xunit;
+using ElBruno.Text2Image.Cli.Commands;
+using Spectre.Console.Cli;
+
+namespace ElBruno.Text2Image.Tests;
+
+/// <summary>
+/// Tests for InitCommand — writes embedded SKILL.md to .github/skills/t2i/ and .claude/skills/t2i/
+/// </summary>
+public class InitCommandTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly string _originalCwd;
+
+    public InitCommandTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), $"t2i-init-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDir);
+        _originalCwd = Directory.GetCurrentDirectory();
+        Directory.SetCurrentDirectory(_testDir);
+    }
+
+    public void Dispose()
+    {
+        Directory.SetCurrentDirectory(_originalCwd);
+        if (Directory.Exists(_testDir))
+        {
+            try
+            {
+                Directory.Delete(_testDir, recursive: true);
+            }
+            catch
+            {
+                // Best effort cleanup
+            }
+        }
+    }
+
+    [Fact]
+    public void Init_WritesBothFiles_WhenTargetAll()
+    {
+        var command = new InitCommand();
+        var settings = new InitCommand.Settings { Target = "all", Force = false };
+        var context = CreateContext();
+
+        var exitCode = command.Execute(context, settings);
+
+        Assert.Equal(0, exitCode);
+        
+        var githubPath = Path.Combine(_testDir, ".github", "skills", "t2i", "SKILL.md");
+        var claudePath = Path.Combine(_testDir, ".claude", "skills", "t2i", "SKILL.md");
+        
+        Assert.True(File.Exists(githubPath), $"Expected {githubPath} to exist");
+        Assert.True(File.Exists(claudePath), $"Expected {claudePath} to exist");
+        
+        var githubContent = File.ReadAllText(githubPath);
+        var claudeContent = File.ReadAllText(claudePath);
+        
+        Assert.Contains("# t2i", githubContent);
+        Assert.NotEmpty(githubContent);
+        Assert.Contains("# t2i", claudeContent);
+        Assert.NotEmpty(claudeContent);
+    }
+
+    [Fact]
+    public void Init_WritesOnlyGithub_WhenTargetGithub()
+    {
+        var command = new InitCommand();
+        var settings = new InitCommand.Settings { Target = "github", Force = false };
+        var context = CreateContext();
+
+        var exitCode = command.Execute(context, settings);
+
+        Assert.Equal(0, exitCode);
+        
+        var githubPath = Path.Combine(_testDir, ".github", "skills", "t2i", "SKILL.md");
+        var claudePath = Path.Combine(_testDir, ".claude", "skills", "t2i", "SKILL.md");
+        
+        Assert.True(File.Exists(githubPath), $"Expected {githubPath} to exist");
+        Assert.False(File.Exists(claudePath), $"Expected {claudePath} NOT to exist");
+        
+        var githubContent = File.ReadAllText(githubPath);
+        Assert.Contains("# t2i", githubContent);
+    }
+
+    [Fact]
+    public void Init_WritesOnlyClaude_WhenTargetClaude()
+    {
+        var command = new InitCommand();
+        var settings = new InitCommand.Settings { Target = "claude", Force = false };
+        var context = CreateContext();
+
+        var exitCode = command.Execute(context, settings);
+
+        Assert.Equal(0, exitCode);
+        
+        var githubPath = Path.Combine(_testDir, ".github", "skills", "t2i", "SKILL.md");
+        var claudePath = Path.Combine(_testDir, ".claude", "skills", "t2i", "SKILL.md");
+        
+        Assert.False(File.Exists(githubPath), $"Expected {githubPath} NOT to exist");
+        Assert.True(File.Exists(claudePath), $"Expected {claudePath} to exist");
+        
+        var claudeContent = File.ReadAllText(claudePath);
+        Assert.Contains("# t2i", claudeContent);
+    }
+
+    [Fact]
+    public void Init_SkipsExistingFile_WithoutForce()
+    {
+        const string sentinel = "PRE-EXISTING CONTENT";
+        var githubPath = Path.Combine(_testDir, ".github", "skills", "t2i", "SKILL.md");
+        
+        // Pre-create file with sentinel content
+        Directory.CreateDirectory(Path.GetDirectoryName(githubPath)!);
+        File.WriteAllText(githubPath, sentinel);
+        
+        var command = new InitCommand();
+        var settings = new InitCommand.Settings { Target = "github", Force = false };
+        var context = CreateContext();
+
+        var exitCode = command.Execute(context, settings);
+
+        Assert.Equal(0, exitCode);
+        
+        var content = File.ReadAllText(githubPath);
+        Assert.Equal(sentinel, content);
+        Assert.DoesNotContain("# t2i", content);
+    }
+
+    [Fact]
+    public void Init_OverwritesExistingFile_WithForce()
+    {
+        const string sentinel = "PRE-EXISTING CONTENT";
+        var githubPath = Path.Combine(_testDir, ".github", "skills", "t2i", "SKILL.md");
+        
+        // Pre-create file with sentinel content
+        Directory.CreateDirectory(Path.GetDirectoryName(githubPath)!);
+        File.WriteAllText(githubPath, sentinel);
+        
+        var command = new InitCommand();
+        var settings = new InitCommand.Settings { Target = "github", Force = true };
+        var context = CreateContext();
+
+        var exitCode = command.Execute(context, settings);
+
+        Assert.Equal(0, exitCode);
+        
+        var content = File.ReadAllText(githubPath);
+        Assert.DoesNotContain(sentinel, content);
+        Assert.Contains("# t2i", content);
+    }
+
+    [Fact]
+    public void Init_CreatesParentDirectories()
+    {
+        // Ensure directories don't exist
+        var githubDir = Path.Combine(_testDir, ".github");
+        var claudeDir = Path.Combine(_testDir, ".claude");
+        
+        Assert.False(Directory.Exists(githubDir));
+        Assert.False(Directory.Exists(claudeDir));
+        
+        var command = new InitCommand();
+        var settings = new InitCommand.Settings { Target = "all", Force = false };
+        var context = CreateContext();
+
+        var exitCode = command.Execute(context, settings);
+
+        Assert.Equal(0, exitCode);
+        
+        Assert.True(Directory.Exists(Path.Combine(githubDir, "skills", "t2i")));
+        Assert.True(Directory.Exists(Path.Combine(claudeDir, "skills", "t2i")));
+        
+        var githubPath = Path.Combine(githubDir, "skills", "t2i", "SKILL.md");
+        var claudePath = Path.Combine(claudeDir, "skills", "t2i", "SKILL.md");
+        
+        Assert.True(File.Exists(githubPath));
+        Assert.True(File.Exists(claudePath));
+    }
+
+    private static CommandContext CreateContext()
+    {
+        var remaining = new FakeRemainingArguments();
+        return new CommandContext(
+            Array.Empty<string>(),
+            remaining,
+            "init",
+            null
+        );
+    }
+
+    private sealed class FakeRemainingArguments : IRemainingArguments
+    {
+        public IReadOnlyList<string> Raw => Array.Empty<string>();
+        public ILookup<string, string?> Parsed => Enumerable.Empty<string>().ToLookup(x => x, x => (string?)null);
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Adds a new `t2i init` command inspired by [Aspire's `aspire agent init` pattern](https://aspire.dev/get-started/ai-coding-agents/). Running it in any repo writes a `SKILL.md` file that teaches AI coding agents (GitHub Copilot, Claude Code, MCP-aware tools) how to use the t2i CLI.

## What ships

### New command

```bash
t2i init                    # writes both .github/skills/t2i/SKILL.md AND .claude/skills/t2i/SKILL.md
t2i init --target github    # only .github/skills/t2i/SKILL.md
t2i init --target claude    # only .claude/skills/t2i/SKILL.md
t2i init --force            # overwrite existing files
```

- Pretty Spectre.Console output: per-target status (created / skipped / overwritten) + summary panel
- Existing files are preserved by default; `--force` to overwrite

### Embedded skill resource

The canonical SKILL.md lives at `src/ElBruno.Text2Image.Cli/Skills/SKILL.md` and is embedded in the CLI assembly. `InitCommand` loads it via `Assembly.GetManifestResourceStream` and writes to disk.

### Sample skill in this repo

The same SKILL.md is committed to `.github/skills/t2i/SKILL.md` and `.claude/skills/t2i/SKILL.md` so any agent working on **this** repo already knows the CLI.

The skill includes: command quick reference, providers table, common workflows (setup / single image / batch loops), 7 agent guidance rules, and secret management strategy.

### Tests

6 xUnit tests in `InitCommandTests.cs` covering:
- Default target writes both files
- `--target github` / `--target claude` write only the requested file
- Without `--force`, existing files are skipped
- With `--force`, existing files are overwritten
- Parent directories are created on demand

✅ All 6 pass on net10.0. Build is 0 warnings / 0 errors across the full solution.

### Docs

Blog post (`docs/20260420-introducing-t2i-cli.md`) updated with a new `🤖 Teach Your AI Agent` section and `t2i init` added to the cheat sheet.

## Files changed

- `src/ElBruno.Text2Image.Cli/Commands/InitCommand.cs` (new)
- `src/ElBruno.Text2Image.Cli/Skills/SKILL.md` (new, embedded)
- `src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj` (embed resource)
- `src/ElBruno.Text2Image.Cli/Program.cs` (register command)
- `src/ElBruno.Text2Image.Cli/README.md` (doc)
- `.github/skills/t2i/SKILL.md` (new sample)
- `.claude/skills/t2i/SKILL.md` (new sample)
- `src/ElBruno.Text2Image.Tests/InitCommandTests.cs` (new)
- `src/ElBruno.Text2Image.Tests/ElBruno.Text2Image.Tests.csproj` (Spectre ref for net10.0)
- `docs/20260420-introducing-t2i-cli.md` (blog post update)

Not closing the PR — leaving it open for your manual review per usual.
