### PR TITLE
chore: align all packages to v0.9.1

### DIFF
--- a/src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj
+++ b/src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj
@@ -15,7 +15,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>t2i</ToolCommandName>
     <PackageId>ElBruno.Text2Image.Cli</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.9.1</Version>
     <Description>Lightweight cross-platform CLI for AI text-to-image generation. Includes cloud providers (Microsoft Foundry FLUX.2, MAI-Image-2). For local CPU/GPU inference, see the upcoming ElBruno.Text2Image.Cli.Full package.</Description>
     <PackageTags>text-to-image;stable-diffusion;flux;mai;ai;image-generation;cli;dotnet-tool</PackageTags>
     <Authors>Bruno Capuano</Authors>

--- a/src/ElBruno.Text2Image.Cpu/ElBruno.Text2Image.Cpu.csproj
+++ b/src/ElBruno.Text2Image.Cpu/ElBruno.Text2Image.Cpu.csproj
@@ -5,7 +5,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>ElBruno.Text2Image.Cpu</PackageId>
-    <Version>0.1.0-preview</Version>
+    <Version>0.9.1</Version>
     <Authors>Bruno Capuano</Authors>
     <Description>CPU runtime for ElBruno.Text2Image. Includes all text-to-image generation functionality with CPU-based inference via ONNX Runtime. Install this for environments without a GPU.</Description>
     <PackageTags>text-to-image;stable-diffusion;image-generation;onnx;onnxruntime;cpu;ai</PackageTags>

--- a/src/ElBruno.Text2Image.Cuda/ElBruno.Text2Image.Cuda.csproj
+++ b/src/ElBruno.Text2Image.Cuda/ElBruno.Text2Image.Cuda.csproj
@@ -5,7 +5,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>ElBruno.Text2Image.Cuda</PackageId>
-    <Version>0.1.0-preview</Version>
+    <Version>0.9.1</Version>
     <Authors>Bruno Capuano</Authors>
     <Description>NVIDIA CUDA GPU acceleration for ElBruno.Text2Image. Install this package instead of ElBruno.Text2Image to enable CUDA-based inference for Stable Diffusion image generation on NVIDIA GPUs.</Description>
     <PackageTags>text-to-image;stable-diffusion;image-generation;onnx;onnxruntime;cuda;gpu;nvidia;ai</PackageTags>

--- a/src/ElBruno.Text2Image.DirectML/ElBruno.Text2Image.DirectML.csproj
+++ b/src/ElBruno.Text2Image.DirectML/ElBruno.Text2Image.DirectML.csproj
@@ -5,7 +5,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>ElBruno.Text2Image.DirectML</PackageId>
-    <Version>0.1.0-preview</Version>
+    <Version>0.9.1</Version>
     <Authors>Bruno Capuano</Authors>
     <Description>DirectML GPU acceleration for ElBruno.Text2Image. Install this package instead of ElBruno.Text2Image to enable DirectML-based inference for Stable Diffusion image generation on AMD, Intel, and NVIDIA GPUs (Windows only).</Description>
     <PackageTags>text-to-image;stable-diffusion;image-generation;onnx;onnxruntime;directml;gpu;ai</PackageTags>

--- a/src/ElBruno.Text2Image.Foundry/ElBruno.Text2Image.Foundry.csproj
+++ b/src/ElBruno.Text2Image.Foundry/ElBruno.Text2Image.Foundry.csproj
@@ -5,7 +5,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>ElBruno.Text2Image.Foundry</PackageId>
-    <Version>0.1.0-preview</Version>
+    <Version>0.9.1</Version>
     <Authors>Bruno Capuano</Authors>
     <Description>Microsoft Foundry cloud image generation for ElBruno.Text2Image. Provides FLUX.2 and MAI-Image-2 text-to-image generation via the Microsoft Foundry REST API. No local models needed — runs in the cloud.</Description>
     <PackageTags>text-to-image;flux2;mai-image-2;image-generation;microsoft-foundry;cloud;ai</PackageTags>

--- a/src/ElBruno.Text2Image/ElBruno.Text2Image.csproj
+++ b/src/ElBruno.Text2Image/ElBruno.Text2Image.csproj
@@ -5,7 +5,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>ElBruno.Text2Image</PackageId>
-    <Version>0.1.0-preview</Version>
+    <Version>0.9.1</Version>
     <Authors>Bruno Capuano</Authors>
     <Description>A .NET library for local text-to-image generation using Stable Diffusion and ONNX Runtime. Supports multiple models (SD 1.5, LCM Dreamshaper) with automatic model download from HuggingFace and native C# inference — no Python dependency.</Description>
     <PackageTags>text-to-image;stable-diffusion;image-generation;onnx;onnxruntime;ai;ml;huggingface;diffusion</PackageTags>


### PR DESCRIPTION
Aligns every ElBruno.Text2Image package on a single version (0.9.1) so libraries and CLI ship on the same rail going forward.

## Changes
- ElBruno.Text2Image: 0.1.0-preview -> 0.9.1
- ElBruno.Text2Image.Foundry: 0.1.0-preview -> 0.9.1
- ElBruno.Text2Image.Cpu: 0.1.0-preview -> 0.9.1
- ElBruno.Text2Image.Cuda: 0.1.0-preview -> 0.9.1
- ElBruno.Text2Image.DirectML: 0.1.0-preview -> 0.9.1
- ElBruno.Text2Image.Cli: 0.2.0 -> 0.9.1

## Why 0.9.1
- v0.9.0 GitHub release already exists (lib release rail)
- cli-v0.2.0 already published to NuGet (immutable)
- 0.9.1 is the next free slot that puts everything on one version

## Release plan after merge
1. Tag `v0.9.1` -> triggers libraries publish to NuGet
2. Tag `cli-v0.9.1` -> triggers CLI tool publish to NuGet