### PR TITLE
fix(cli): auto-bump dimensions for MAI-Image-2 below 768px minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.10.1] - 2026-04-20
+
+### Fixed
+- **MAI-Image-2 default dimensions** — `t2i "..."` with no `--width`/`--height` flags
+  no longer fails with `MAI-Image-2 requires both dimensions to be at least 768px`.
+  The CLI's generic 512px default is now silently bumped to MAI's preferred 1024px
+  when the selected provider is `foundry-mai2`, with a note shown in the progress
+  output. Users can still pass explicit dimensions ≥ 768px.
+
 ## [0.10.0] - 2025-04-20
 
 ### Added

--- a/src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj
+++ b/src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj
@@ -15,7 +15,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>t2i</ToolCommandName>
     <PackageId>ElBruno.Text2Image.Cli</PackageId>
-    <Version>0.10.0</Version>
+    <Version>0.10.1</Version>
     <Description>Lightweight cross-platform CLI for AI text-to-image generation. Includes cloud providers (Microsoft Foundry FLUX.2, MAI-Image-2). For local CPU/GPU inference, see the upcoming ElBruno.Text2Image.Cli.Full package.</Description>
     <PackageTags>text-to-image;stable-diffusion;flux;mai;ai;image-generation;cli;dotnet-tool</PackageTags>
     <Authors>Bruno Capuano</Authors>

--- a/src/ElBruno.Text2Image.Cli/Providers/FoundryMaiImage2Adapter.cs
+++ b/src/ElBruno.Text2Image.Cli/Providers/FoundryMaiImage2Adapter.cs
@@ -105,10 +105,18 @@ internal sealed class FoundryMaiImage2Adapter : IProviderAdapter
         var width = req.Width > 0 ? req.Width : 1024;
         var height = req.Height > 0 ? req.Height : 1024;
 
+        // MAI-Image-2 requires both dimensions ≥ 768px. The CLI's generic default is
+        // 512 (suitable for SD/FLUX), so silently bump to MAI's preferred 1024 when
+        // the request is below the minimum, surfacing a note via the progress channel.
         if (width < MinDimension || height < MinDimension)
         {
-            throw new ArgumentException(
-                $"MAI-Image-2 requires both dimensions to be at least {MinDimension}px");
+            var originalWidth = width;
+            var originalHeight = height;
+            width = Math.Max(width, 1024);
+            height = Math.Max(height, 1024);
+            progress?.Report(new GenerationProgress(
+                0, 1,
+                $"Adjusted size from {originalWidth}x{originalHeight} to {width}x{height} (MAI-Image-2 minimum is {MinDimension}px)"));
         }
 
         if (width * height > MaxTotalPixels)


### PR DESCRIPTION
## Summary

Fixes the bug reported on the CLI:

`
$ t2i "a pixelated racoon doing surf in Canada"
? Generation failed: MAI-Image-2 requires both dimensions to be at least 768px
`

The CLI's generic `--width`/`--height` default of `512` (suitable for SD/FLUX) was being passed straight through to the `foundry-mai2` provider, which rejects anything below `768px`.

## Fix

`FoundryMaiImage2Adapter` now silently bumps under-minimum dimensions to `1024x1024` (MAI's preferred default) and surfaces a one-line note via the progress channel instead of throwing. Explicit dimensions `>= 768` are unaffected.

## Changes

- `src/ElBruno.Text2Image.Cli/Providers/FoundryMaiImage2Adapter.cs` - auto-bump logic
- `src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj` - version 0.10.0 -> 0.10.1
- `CHANGELOG.md` - 0.10.1 entry

## Validation

- `dotnet build` clean (0 warnings, 0 errors)
- `dotnet test` all 404 tests pass (net8.0 + net10.0)
