### PR TITLE
fix(cli): remove -h short alias from --height (collided with --help)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.10.2] - 2026-04-20
+
+### Fixed
+- **`-h` short option collision** — `t2i -h` now correctly shows help instead of
+  failing with `Option 'height' is defined but no value has been provided`. The
+  `--height` option no longer registers `-h` as a short alias (it conflicted with
+  the built-in `-h, --help`). `--width` still accepts `-w`; height must be passed
+  via the long form `--height <pixels>`.
+
 ## [0.10.1] - 2026-04-20
 
 ### Fixed

--- a/docs/cli-tool.md
+++ b/docs/cli-tool.md
@@ -104,7 +104,7 @@ t2i "<prompt>" [options]
 | `--provider` | Provider ID (cpu, cuda, directml, foundry-flux2, foundry-mai2) | Config default |
 | `--out`, `-o` | Output file path | `output.png` |
 | `--width`, `-w` | Image width in pixels | 512 (local), 1024 (cloud) |
-| `--height`, `-h` | Image height in pixels | 512 (local), 1024 (cloud) |
+| `--height` | Image height in pixels | 512 (local), 1024 (cloud) |
 | `--steps`, `-s` | Inference steps (local only) | 20 |
 | `--endpoint` | Cloud endpoint URL (override config) | From config |
 | `--api-key` | Cloud API key (override secrets) | From secrets |

--- a/src/ElBruno.Text2Image.Cli/Commands/GenerateCommand.cs
+++ b/src/ElBruno.Text2Image.Cli/Commands/GenerateCommand.cs
@@ -45,7 +45,7 @@ internal sealed class GenerateCommand : AsyncCommand<GenerateCommand.Settings>
         [DefaultValue(512)]
         public int Width { get; init; } = 512;
 
-        [CommandOption("--height|-h")]
+        [CommandOption("--height")]
         [Description("Image height in pixels (default: 512)")]
         [DefaultValue(512)]
         public int Height { get; init; } = 512;

--- a/src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj
+++ b/src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj
@@ -15,7 +15,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>t2i</ToolCommandName>
     <PackageId>ElBruno.Text2Image.Cli</PackageId>
-    <Version>0.10.1</Version>
+    <Version>0.10.2</Version>
     <Description>Lightweight cross-platform CLI for AI text-to-image generation. Includes cloud providers (Microsoft Foundry FLUX.2, MAI-Image-2). For local CPU/GPU inference, see the upcoming ElBruno.Text2Image.Cli.Full package.</Description>
     <PackageTags>text-to-image;stable-diffusion;flux;mai;ai;image-generation;cli;dotnet-tool</PackageTags>
     <Authors>Bruno Capuano</Authors>


### PR DESCRIPTION
## Summary

Fixes the `-h` short option collision reported on the CLI:

```
$ t2i -h
Error: Option 'height' is defined but no value has been provided.
       -h
       ^^ No value provided
```

`--height` was registered with `-h` as a short alias, which Spectre.Console also reserves for the built-in `--help` flag. Whichever option binds first wins, leaving the other broken.

## Fix

Drop the `-h` alias from `--height`. Width keeps `-w`. Height must now be passed via the long form (`--height <pixels>`).

After:

```
$ t2i -h
USAGE:
    t2i <prompt> [OPTIONS] [COMMAND]
...
        --height      512        Image height in pixels (default: 512)
```

## Changes

- `src/ElBruno.Text2Image.Cli/Commands/GenerateCommand.cs` — drop `-h` alias
- `docs/cli-tool.md` — update options table
- `src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj` — 0.10.1 → 0.10.2
- `CHANGELOG.md` — 0.10.2 entry

Skills (`Skills/SKILL.md`, `.github/skills/t2i/SKILL.md`, `.claude/skills/t2i/SKILL.md`) and the launch blog post (`docs/20260420-introducing-t2i-cli.md`) only used the long-form `--height`, so no changes there.

## Validation

- `dotnet build` clean (0 warnings, 0 errors)
- `dotnet test` all 404 tests pass
- `dotnet run -- -h` now shows help correctly (verified locally)
