### PR TITLE
Fix CLI package validation step to read nupkg as zip

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Validate CLI tool package
         run: |
           CLI_PKG=$(ls artifacts/ElBruno.Text2Image.Cli.*.nupkg | head -n 1)
-          tar -tf "$CLI_PKG" | grep -q "tools/net10.0/any/DotnetToolSettings.xml"
+          unzip -l "$CLI_PKG" | grep -q "tools/net10.0/any/DotnetToolSettings.xml"
 
           mkdir -p artifacts/tool-validation
           pushd artifacts/tool-validation
@@ -172,7 +172,7 @@ jobs:
       - name: Validate CLI tool package
         run: |
           CLI_PKG=$(ls artifacts/ElBruno.Text2Image.Cli.*.nupkg | head -n 1)
-          tar -tf "$CLI_PKG" | grep -q "tools/net10.0/any/DotnetToolSettings.xml"
+          unzip -l "$CLI_PKG" | grep -q "tools/net10.0/any/DotnetToolSettings.xml"
 
           mkdir -p artifacts/tool-validation
           pushd artifacts/tool-validation


### PR DESCRIPTION
Summary: switch nupkg inspection from tar to unzip in both CLI validation steps so ubuntu runners validate tool packages correctly.