### PR TITLE
Fix full-release CLI packaging to always generate DotnetToolSettings.xml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,13 +98,18 @@ jobs:
         run: |
           for proj in \
             src/ElBruno.Text2Image/ElBruno.Text2Image.csproj \
-            src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj \
             src/ElBruno.Text2Image.Cpu/ElBruno.Text2Image.Cpu.csproj \
             src/ElBruno.Text2Image.Cuda/ElBruno.Text2Image.Cuda.csproj \
             src/ElBruno.Text2Image.DirectML/ElBruno.Text2Image.DirectML.csproj \
             src/ElBruno.Text2Image.Foundry/ElBruno.Text2Image.Foundry.csproj; do
             dotnet pack "$proj" -c Release --no-build -o artifacts -p:Version=${{ steps.version.outputs.version }}
           done
+
+          # Pack tool package with build to ensure DotnetToolSettings.xml is generated.
+          dotnet pack src/ElBruno.Text2Image.Cli/ElBruno.Text2Image.Cli.csproj \
+            -c Release \
+            -o artifacts \
+            -p:Version=${{ steps.version.outputs.version }}
 
       - name: Validate CLI tool package
         run: |


### PR DESCRIPTION
## Summary
- remove CLI project from the --no-build pack loop in full releases
- pack CLI separately with build enabled to guarantee tool settings generation
- keep CLI package validation step before NuGet push