### PR TITLE
Add durable guardrails for CLI dotnet-tool packaging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,6 +135,30 @@ jobs:
       - name: Push to NuGet.org
         run: dotnet nuget push artifacts/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
+      - name: Verify published CLI tool from NuGet.org
+        run: |
+          dotnet nuget locals all --clear
+          for i in {1..15}; do
+            rm -rf artifacts/post-publish-verify
+            mkdir -p artifacts/post-publish-verify
+            pushd artifacts/post-publish-verify
+            dotnet new tool-manifest --force
+            if dotnet tool install ElBruno.Text2Image.Cli \
+              --version "${{ steps.version.outputs.version }}" \
+              --source "https://api.nuget.org/v3/index.json" \
+              --ignore-failed-sources \
+              --verbosity minimal; then
+              dotnet tool run t2i -- --help
+              popd
+              exit 0
+            fi
+            popd
+            echo "Package not available yet on NuGet.org (attempt $i/15). Retrying..."
+            sleep 20
+          done
+          echo "ERROR: Published CLI package could not be installed from NuGet.org."
+          exit 1
+
       - name: Upload nupkg artifact
         uses: actions/upload-artifact@v4
         with:
@@ -197,6 +221,30 @@ jobs:
 
       - name: Push to NuGet.org
         run: dotnet nuget push artifacts/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Verify published CLI tool from NuGet.org
+        run: |
+          dotnet nuget locals all --clear
+          for i in {1..15}; do
+            rm -rf artifacts/post-publish-verify
+            mkdir -p artifacts/post-publish-verify
+            pushd artifacts/post-publish-verify
+            dotnet new tool-manifest --force
+            if dotnet tool install ElBruno.Text2Image.Cli \
+              --version "${{ steps.version.outputs.version }}" \
+              --source "https://api.nuget.org/v3/index.json" \
+              --ignore-failed-sources \
+              --verbosity minimal; then
+              dotnet tool run t2i -- --help
+              popd
+              exit 0
+            fi
+            popd
+            echo "Package not available yet on NuGet.org (attempt $i/15). Retrying..."
+            sleep 20
+          done
+          echo "ERROR: Published CLI package could not be installed from NuGet.org."
+          exit 1
 
       - name: Upload nupkg artifact
         uses: actions/upload-artifact@v4

--- a/src/ElBruno.Text2Image.Tests/Cli/ToolPackagingGuardrailTests.cs
+++ b/src/ElBruno.Text2Image.Tests/Cli/ToolPackagingGuardrailTests.cs
@@ -1,0 +1,82 @@
+#if NET10_0_OR_GREATER
+using System.Diagnostics;
+using System.IO.Compression;
+using Xunit;
+
+namespace ElBruno.Text2Image.Tests.Cli;
+
+public class ToolPackagingGuardrailTests
+{
+    [Fact]
+    public async Task CliPackage_ContainsDotnetToolSettings_AndInstallsAsTool()
+    {
+        var projectPath = Path.GetFullPath(
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "ElBruno.Text2Image.Cli", "ElBruno.Text2Image.Cli.csproj"));
+
+        var outputDir = Path.Combine(Path.GetTempPath(), $"t2i-pack-guardrail-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(outputDir);
+
+        try
+        {
+            var version = "9.9.9-guardrail";
+            await RunProcessAsync(
+                "dotnet",
+                $"pack \"{projectPath}\" -c Release --no-restore -o \"{outputDir}\" -p:Version={version}",
+                outputDir);
+
+            var packagePath = Directory
+                .GetFiles(outputDir, "ElBruno.Text2Image.Cli.*.nupkg", SearchOption.TopDirectoryOnly)
+                .Single(path => !path.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase));
+
+            using (var archive = ZipFile.OpenRead(packagePath))
+            {
+                Assert.Contains(
+                    archive.Entries,
+                    e => string.Equals(e.FullName, "tools/net10.0/any/DotnetToolSettings.xml", StringComparison.Ordinal));
+            }
+
+            var installDir = Path.Combine(outputDir, "tool-install");
+            Directory.CreateDirectory(installDir);
+
+            await RunProcessAsync("dotnet", "new tool-manifest --force", installDir);
+            await RunProcessAsync(
+                "dotnet",
+                $"tool install ElBruno.Text2Image.Cli --version {version} --add-source \"{outputDir}\" --ignore-failed-sources",
+                installDir);
+            await RunProcessAsync("dotnet", "tool run t2i -- --help", installDir);
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir))
+            {
+                Directory.Delete(outputDir, recursive: true);
+            }
+        }
+    }
+
+    private static async Task RunProcessAsync(string fileName, string arguments, string workingDirectory)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(psi);
+        Assert.NotNull(process);
+
+        var stdOut = await process.StandardOutput.ReadToEndAsync();
+        var stdErr = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        Assert.True(
+            process.ExitCode == 0,
+            $"Command failed: {fileName} {arguments}{Environment.NewLine}STDOUT:{Environment.NewLine}{stdOut}{Environment.NewLine}STDERR:{Environment.NewLine}{stdErr}");
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add a dedicated test (ToolPackagingGuardrailTests) that packs the CLI, asserts DotnetToolSettings.xml is present, and validates local tool installation/execution
- add post-publish guardrails in both NuGet publish jobs that install the just-published CLI package from nuget.org and run 	2i --help
- include retry logic for NuGet propagation delays to avoid flaky false negatives