### PR TITLE
Fix README Twitter URL in About the Author section

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ If you like this project, consider following my work across platforms:
 - 💻 **Blog**: [ElBruno.com](https://elbruno.com) — Deep dives on embeddings, RAG, .NET, and local AI
 - 📺 **YouTube**: [youtube.com/elbruno](https://www.youtube.com/elbruno) — Demos, tutorials, and live coding
 - 🔗 **LinkedIn**: [@elbruno](https://www.linkedin.com/in/elbruno/) — Professional updates and insights
-- 𝕏 **Twitter**: [@elbruno](https://www.x.com/in/elbruno/) — Quick tips, releases, and tech news
+- 𝕏 **Twitter**: [@elbruno](https://www.x.com/elbruno/) — Quick tips, releases, and tech news
 
 ## License
 


### PR DESCRIPTION
Closes #38\n\nDocs-only change: correct the About the Author Twitter/X URL in README.md from https://www.x.com/in/elbruno/ to https://www.x.com/elbruno/.